### PR TITLE
ReadableUtils and string Preferences

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -314,6 +314,8 @@ fn compile_gecko_media() {
         "xpcom/ds/nsTArray.cpp",
         "xpcom/ds/nsTObserverArray.cpp",
         "xpcom/io/nsDirectoryService.cpp",
+        "xpcom/string/nsReadableUtilsSSE2.cpp",
+        "xpcom/string/nsUTF8UtilsSSE2.cpp",
         "xpcom/string/unified.cpp",
         "xpcom/threads/EventQueue.cpp",
         "xpcom/threads/nsILabelableRunnable.cpp",

--- a/gecko/glue/Preferences.cpp
+++ b/gecko/glue/Preferences.cpp
@@ -9,6 +9,7 @@
 #include "mozilla/BinarySearch.h"
 #include "nsString.h"
 #include "mozilla/StaticPtr.h"
+#include "gecko_media_prefs.h"
 
 namespace mozilla {
 
@@ -108,24 +109,6 @@ Preferences::GetDirty(bool* _retval)
   MOZ_CRASH("Called unimplemented Preferences::GetDirty");
   return NS_ERROR_NOT_IMPLEMENTED;
 }
-
-struct BoolPref
-{
-  const char* mName;
-  const bool mValue;
-};
-
-struct IntPref
-{
-  const char* mName;
-  const int32_t mValue;
-};
-
-struct StringPref
-{
-  const char* mName;
-  const char* mValue;
-};
 
 #include "prefs_common.cpp"
 #if defined(MOZ_WIDGET_ANDROID)

--- a/gecko/glue/include/gecko_media_prefs.h
+++ b/gecko/glue/include/gecko_media_prefs.h
@@ -1,0 +1,32 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef gecko_media_prefs
+#define gecko_media_prefs
+
+namespace mozilla {
+
+struct BoolPref
+{
+  const char* mName;
+  const bool mValue;
+};
+
+struct IntPref
+{
+  const char* mName;
+  const int32_t mValue;
+};
+
+struct StringPref
+{
+  const char* mName;
+  const char* mValue;
+};
+
+} // namespace mozilla
+
+#endif

--- a/gecko/glue/prefs_common.cpp
+++ b/gecko/glue/prefs_common.cpp
@@ -21,6 +21,7 @@ static const BoolPref sCommonBoolPrefs[] = {
 #endif // #if defined(XP_MACOSX)
 #if defined(MOZ_FFMPEG)
 #if defined(XP_MACOSX)
+#else
   { "media.ffmpeg.enabled", true },
 #endif // #if defined(MOZ_FFMPEG)
 #endif // #if defined(XP_MACOSX)
@@ -41,6 +42,7 @@ static const BoolPref sCommonBoolPrefs[] = {
 #endif // #if defined(MOZ_WEBRTC_HARDWARE_AEC_NS)
 #ifdef MOZ_WEBRTC
 #if defined(MOZ_WEBRTC_HARDWARE_AEC_NS)
+#else
   { "media.getusermedia.aec_enabled", true },
 #endif // #ifdef MOZ_WEBRTC
 #endif // #if defined(MOZ_WEBRTC_HARDWARE_AEC_NS)
@@ -61,6 +63,7 @@ static const BoolPref sCommonBoolPrefs[] = {
 #endif // #if defined(MOZ_WEBRTC_HARDWARE_AEC_NS)
 #ifdef MOZ_WEBRTC
 #if defined(MOZ_WEBRTC_HARDWARE_AEC_NS)
+#else
   { "media.getusermedia.noise_enabled", true },
 #endif // #ifdef MOZ_WEBRTC
 #endif // #if defined(MOZ_WEBRTC_HARDWARE_AEC_NS)
@@ -88,6 +91,7 @@ static const BoolPref sCommonBoolPrefs[] = {
   { "media.mediasource.webm.enabled", false },
 #endif // #if defined(XP_WIN) || defined(XP_MACOSX) || defined(MOZ_WIDGET_ANDROID)
 #if defined(XP_WIN) || defined(XP_MACOSX) || defined(MOZ_WIDGET_ANDROID)
+#else
   { "media.mediasource.webm.enabled", true },
 #endif // #if defined(XP_WIN) || defined(XP_MACOSX) || defined(MOZ_WIDGET_ANDROID)
 #ifdef MOZ_APPLEMEDIA
@@ -120,6 +124,7 @@ static const BoolPref sCommonBoolPrefs[] = {
 #endif // #if defined(XP_MACOSX)
 #ifdef MOZ_WEBRTC
 #if defined(XP_MACOSX)
+#else
   { "media.navigator.audio.full_duplex", false },
 #endif // #ifdef MOZ_WEBRTC
 #endif // #if defined(XP_MACOSX)
@@ -335,6 +340,7 @@ static const IntPref sCommonIntPrefs[] = {
 #endif // #if defined(XP_MACOSX)
 #ifdef MOZ_WEBRTC
 #if defined(XP_MACOSX)
+#else
   { "media.getusermedia.playout_delay", 50 },
 #endif // #ifdef MOZ_WEBRTC
 #endif // #if defined(XP_MACOSX)
@@ -402,6 +408,7 @@ static const IntPref sCommonIntPrefs[] = {
 #endif // #if defined(XP_MACOSX)
 #ifdef MOZ_WEBRTC
 #if defined(XP_MACOSX)
+#else
   { "media.peerconnection.capture_delay", 50 },
 #endif // #ifdef MOZ_WEBRTC
 #endif // #if defined(XP_MACOSX)
@@ -456,6 +463,7 @@ static const StringPref sCommonStringPrefs[] = {
   { "media.decoder-doctor.notifications-allowed", "MediaWMFNeeded,MediaWidevineNoWMF,MediaCannotInitializePulseAudio,MediaCannotPlayNoDecoders,MediaUnsupportedLibavcodec,MediaDecodeError" },
 #endif // #ifdef NIGHTLY_BUILD
 #ifdef NIGHTLY_BUILD
+#else
   { "media.decoder-doctor.notifications-allowed", "MediaWMFNeeded,MediaWidevineNoWMF,MediaCannotInitializePulseAudio,MediaCannotPlayNoDecoders,MediaUnsupportedLibavcodec" },
 #endif // #ifdef NIGHTLY_BUILD
   { "media.default_volume", "1.0" },
@@ -463,6 +471,7 @@ static const StringPref sCommonStringPrefs[] = {
   { "media.getusermedia.screensharing.allowed_domains", "webex.com,*.webex.com,ciscospark.com,*.ciscospark.com,projectsquared.com,*.projectsquared.com,*.room.co,room.co,beta.talky.io,talky.io,*.clearslide.com,appear.in,*.appear.in,tokbox.com,*.tokbox.com,*.sso.francetelecom.fr,*.si.francetelecom.fr,*.sso.infra.ftgroup,*.multimedia-conference.orange-business.com,*.espacecollaboration.orange-business.com,free.gotomeeting.com,g2m.me,*.g2m.me,*.mypurecloud.com,*.mypurecloud.com.au,spreed.me,*.spreed.me,*.spreed.com,air.mozilla.org,*.circuit.com,*.yourcircuit.com,circuit.siemens.com,yourcircuit.siemens.com,circuitsandbox.net,*.unify.com,tandi.circuitsandbox.net,*.ericsson.net,*.cct.ericsson.net,*.opentok.com,*.conf.meetecho.com,meet.jit.si,*.meet.jit.si,web.stage.speakeasyapp.net,web.speakeasyapp.net,*.hipchat.me,*.beta-wspbx.com,*.wspbx.com,*.unifiedcloudit.com,*.smartboxuc.com,*.smartbox-uc.com,*.panterranetworks.com,pexipdemo.com,*.pexipdemo.com,pex.me,*.pex.me,*.rd.pexip.com,1click.io,*.1click.io,*.fuze.com,*.fuzemeeting.com,*.thinkingphones.com,gotomeeting.com,*.gotomeeting.com,gotowebinar.com,*.gotowebinar.com,gototraining.com,*.gototraining.com,citrix.com,*.citrix.com,expertcity.com,*.expertcity.com,citrixonline.com,*.citrixonline.com,g2m.me,*.g2m.me,gotomeet.me,*.gotomeet.me,gotomeet.at,*.gotomeet.at,miriadaxdes.miriadax.net,certificacion.miriadax.net,miriadax.net,*.wire.com,sylaps.com,*.sylaps.com,bluejeans.com,*.bluejeans.com,*.a.bluejeans.com,*.bbcollab.com" },
 #endif // #ifdef RELEASE_OR_BETA
 #ifdef RELEASE_OR_BETA
+#else
   { "media.getusermedia.screensharing.allowed_domains", "mozilla.github.io,webex.com,*.webex.com,ciscospark.com,*.ciscospark.com,projectsquared.com,*.projectsquared.com,*.room.co,room.co,beta.talky.io,talky.io,*.clearslide.com,appear.in,*.appear.in,tokbox.com,*.tokbox.com,*.sso.francetelecom.fr,*.si.francetelecom.fr,*.sso.infra.ftgroup,*.multimedia-conference.orange-business.com,*.espacecollaboration.orange-business.com,free.gotomeeting.com,g2m.me,*.g2m.me,*.mypurecloud.com,*.mypurecloud.com.au,spreed.me,*.spreed.me,*.spreed.com,air.mozilla.org,*.circuit.com,*.yourcircuit.com,circuit.siemens.com,yourcircuit.siemens.com,circuitsandbox.net,*.unify.com,tandi.circuitsandbox.net,*.ericsson.net,*.cct.ericsson.net,*.opentok.com,*.conf.meetecho.com,meet.jit.si,*.meet.jit.si,web.stage.speakeasyapp.net,web.speakeasyapp.net,*.hipchat.me,*.beta-wspbx.com,*.wspbx.com,*.unifiedcloudit.com,*.smartboxuc.com,*.smartbox-uc.com,*.panterranetworks.com,pexipdemo.com,*.pexipdemo.com,pex.me,*.pex.me,*.rd.pexip.com,1click.io,*.1click.io,*.fuze.com,*.fuzemeeting.com,*.thinkingphones.com,gotomeeting.com,*.gotomeeting.com,gotowebinar.com,*.gotowebinar.com,gototraining.com,*.gototraining.com,citrix.com,*.citrix.com,expertcity.com,*.expertcity.com,citrixonline.com,*.citrixonline.com,g2m.me,*.g2m.me,gotomeet.me,*.gotomeet.me,gotomeet.at,*.gotomeet.at,miriadaxdes.miriadax.net,certificacion.miriadax.net,miriadax.net,*.wire.com,sylaps.com,*.sylaps.com,bluejeans.com,*.bluejeans.com,*.a.bluejeans.com,*.bbcollab.com" },
 #endif // #ifdef RELEASE_OR_BETA
   { "media.gmp-manager.certs.1.commonName", "aus5.mozilla.org" },

--- a/gecko/glue/prefs_desktop.cpp
+++ b/gecko/glue/prefs_desktop.cpp
@@ -3,12 +3,14 @@ static const BoolPref sDesktopBoolPrefs[] = {
   { "media.eme.enabled", false },
 #endif // #ifdef XP_LINUX
 #ifdef XP_LINUX
+#else
   { "media.eme.enabled", true },
 #endif // #ifdef XP_LINUX
 #ifdef NIGHTLY_BUILD
   { "media.eme.vp9-in-mp4.enabled", true },
 #endif // #ifdef NIGHTLY_BUILD
 #ifdef NIGHTLY_BUILD
+#else
   { "media.eme.vp9-in-mp4.enabled", false },
 #endif // #ifdef NIGHTLY_BUILD
   { "media.gmp-provider.enabled", true },

--- a/gecko/src/xpcom/string/nsReadableUtilsSSE2.cpp
+++ b/gecko/src/xpcom/string/nsReadableUtilsSSE2.cpp
@@ -1,0 +1,70 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include <emmintrin.h>
+
+#include "nsReadableUtilsImpl.h"
+
+namespace mozilla {
+namespace SSE2 {
+
+static inline bool
+is_zero (__m128i x)
+{
+  return
+    _mm_movemask_epi8(_mm_cmpeq_epi8(x, _mm_setzero_si128())) == 0xffff;
+}
+
+int32_t
+FirstNonASCII(const char16_t* aBegin, const char16_t* aEnd)
+{
+  const size_t kNumUnicharsPerVector = sizeof(__m128i) / sizeof(char16_t);
+  typedef NonASCIIParameters<sizeof(size_t)> p;
+  const size_t kMask = p::mask();
+  const uintptr_t kXmmAlignMask = 0xf;
+  const uint16_t kShortMask = 0xff80;
+  const size_t kNumUnicharsPerWord = p::numUnicharsPerWord();
+
+  const char16_t* idx = aBegin;
+
+  // Align ourselves to a 16-byte boundary as required by _mm_load_si128
+  for (; idx != aEnd && ((uintptr_t(idx) & kXmmAlignMask) != 0); idx++) {
+    if (!IsASCII(*idx)) {
+      return idx - aBegin;
+    }
+  }
+
+  // Check one XMM register (16 bytes) at a time.
+  const char16_t* vectWalkEnd = aligned(aEnd, kXmmAlignMask);
+  __m128i vectmask = _mm_set1_epi16(static_cast<int16_t>(kShortMask));
+  for (; idx != vectWalkEnd; idx += kNumUnicharsPerVector) {
+    const __m128i vect = *reinterpret_cast<const __m128i*>(idx);
+    if (!is_zero(_mm_and_si128(vect, vectmask))) {
+      return idx - aBegin;
+    }
+  }
+
+  // Check one word at a time.
+  const char16_t* wordWalkEnd = aligned(aEnd, p::alignMask());
+  for(; idx != wordWalkEnd; idx += kNumUnicharsPerWord) {
+    const size_t word = *reinterpret_cast<const size_t*>(idx);
+    if (word & kMask) {
+      return idx - aBegin;
+    }
+  }
+
+  // Take care of the remainder one character at a time.
+  for (; idx != aEnd; idx++) {
+    if (!IsASCII(*idx)) {
+      return idx - aBegin;
+    }
+  }
+
+  return -1;
+}
+
+} // namespace SSE2
+} // namespace mozilla

--- a/gecko/src/xpcom/string/unified.cpp
+++ b/gecko/src/xpcom/string/unified.cpp
@@ -8,5 +8,4 @@
 #include "nsStringObsolete.cpp"
 #include "nsSubstring.cpp"
 #include "nsSubstringTuple.cpp"
-#include "nsUTF8UtilsSSE2.cpp"
 #include "precompiled_templates.cpp"

--- a/import.py
+++ b/import.py
@@ -715,7 +715,11 @@ def extract_preferences(lines):
         elif line.startswith("pref"):
             (pref, value, kind) = extract_pref_from_line(line)
             prefs[kind] += [((pref, value), guards[:])]
+        elif line.startswith("#else"):
+            guards.append(line)
         elif line.startswith("#endif"):
+            if guards[-1].startswith("#else"):
+                guards.pop()
             guards.pop()
         i += 1
     # Sort the lists based on pref name, so we can binary search it in
@@ -732,7 +736,8 @@ def write_pref_group(dst, prefs, prefix, pref_type):
             dst.write(guard)
         dst.write("  { " + name + ", " + value + " },\n")
         for guard in guards:
-            dst.write("#endif // " + guard)
+            if not guard.startswith("#else"):
+                dst.write("#endif // " + guard)
     dst.write("};\n\n")
 
 def copy_media_prefs(src_pref_file, dst_pref_file, prefix):

--- a/import.py
+++ b/import.py
@@ -477,6 +477,7 @@ src_files = [
     "xpcom/string/nsDependentSubstring.cpp",
     "xpcom/string/nsPromiseFlatString.cpp",
     "xpcom/string/nsReadableUtils.cpp",
+    "xpcom/string/nsReadableUtilsSSE2.cpp",
     "xpcom/string/nsString.cpp",
     "xpcom/string/nsStringComparator.cpp",
     "xpcom/string/nsStringObsolete.cpp",
@@ -670,7 +671,7 @@ def write_gecko_revision_file(src_dir):
 
 def write_unified_cpp_file(dir):
     cpps = sorted([f for f in listdir(dir)
-      if f.endswith(".cpp") and not os.path.basename(f).startswith("nsT")])
+      if f.endswith(".cpp") and not os.path.basename(f).startswith("nsT") and not "SSE" in f])
     with open(dir + os.path.sep + "unified.cpp", "w") as f:
       for cpp_file in cpps:
         f.write("#include \"{}\"\n".format(cpp_file))


### PR DESCRIPTION
- NS_ConvertUTF8toUTF16 and nsAString.EqualsASCII were failing as we didn't have ReadableUtils imported. So import that; it only builds in non-unified mode.
- Change import.py so that it handles #else pre-processor directives in pref files; this was causing us to not get some prefs correctly.
- Add test for every pref that we get the value that we expect.