### PR TITLE
Attempts to fix Travis on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ addons:
       - gcc-5
       - g++-5
       - libpulse-dev
+      - pulseaudio
+      - dbus-x11
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
@@ -27,6 +29,11 @@ before_install:
   - source ../venv/bin/activate
   - python --version
   - pip install servo-tidy
+  - if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
+      export DISPLAY=:99.0;
+      /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset;
+      dbus-launch pulseaudio --start;
+    fi;
 script:
   - servo-tidy
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
 language: rust
 rust:
-  - 1.19.0
   - nightly
 os:
   - linux
@@ -11,11 +10,16 @@ notifications:
 addons:
   apt:
     sources:
+      - ubuntu-toolchain-r-test
       - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.8 main'
         keyurl: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
       - sourceline: 'ppa:jonathonf/python-2.7'
     packages:
       - python
+      - gcc-5
+      - g++-5
+      - libpulse-dev
+
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install zlib; fi
@@ -25,4 +29,9 @@ before_install:
   - pip install servo-tidy
 script:
   - servo-tidy
-  - cargo test --verbose
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      cargo test --verbose;
+    else
+      CC=gcc-5 CXX=g++-5 cargo test --verbose --features pulseaudio;
+    fi;
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "gecko-media"
 version = "0.1.0"
+license = "MPL-2.0"
 authors = ["Chris Pearce <cpearce@mozilla.com>", "Philippe Normand <philn@igalia.com>"]
 build = "build.rs"
 

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 extern crate cc;
 
 use std::env;

--- a/servo-tidy.toml
+++ b/servo-tidy.toml
@@ -1,0 +1,9 @@
+
+[ignore]
+files = [
+  "./import.py"
+]
+directories = [
+  "./gecko",
+  "./target"
+]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #[allow(unused_extern_crates)]
 
 #[cfg(feature = "pulseaudio")]
@@ -5,7 +9,6 @@ extern crate cubeb_pulse;
 
 #[cfg(test)]
 mod tests {
-
     extern "C" {
         fn TestGecko();
     }


### PR DESCRIPTION
The default toolchain (gcc 4.8) is too old for us. Also enable Pulseaudio
support on Linux, this is required for the tests to pass on that platform.