### PR TITLE
Add Rust API for startup, shutdown, and canPlayType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ cubeb-pulse = { git = "https://github.com/djg/cubeb-pulse-rs", branch = "dev", o
 
 [build-dependencies]
 cc = "1.0"
+bindgen = "0.30.0"
 
 [dependencies]
 mime = "0.3.5"

--- a/build.rs
+++ b/build.rs
@@ -2,9 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+extern crate bindgen;
 extern crate cc;
 
 use std::env;
+use std::path::PathBuf;
 
 fn make_builder(cpp: bool) -> cc::Build {
     let mut b = cc::Build::new();
@@ -834,6 +836,7 @@ fn compile_gecko_media() {
         "AbstractThread.cpp",
         "BlockingResourceBase.cpp",
         "CooperativeThreadPool.cpp",
+        "GeckoMedia.cpp",
         "ImageContainer.cpp",
         "InputEventStatistics.cpp",
         "nsDebugImpl.cpp",
@@ -879,7 +882,20 @@ fn compile_gecko_media() {
     cpp_builder.compile("gecko_media_cpp");
 }
 
+fn compile_bindings() {
+    let bindings = bindgen::Builder::default()
+        .header("gecko/glue/include/wrapper.hpp")
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}
+
 fn main() {
+    compile_bindings();
     compile_gecko_media();
     compile_tests();
 }

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -28,3 +28,9 @@ GeckoMedia_Shutdown()
   mozilla::Preferences::Shutdown();
   NS_ShutdownXPCOM(nullptr);
 }
+
+CanPlayTypeResult
+GeckoMedia_CanPlayType(const char* aMimeType)
+{
+  return CanPlayTypeResult::No;
+}

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -1,0 +1,30 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "GeckoMedia.h"
+
+#include "mozilla/Logging.h"
+#include "mozilla/Preferences.h"
+#include "mozilla/SharedThreadPool.h"
+#include "nsThreadManager.h"
+#include "nsThreadUtils.h"
+
+void
+GeckoMedia_Initialize()
+{
+  mozilla::LogModule::Init();
+  NS_SetMainThread();
+  nsThreadManager::get().Init();
+  NS_InitMinimalXPCOM();
+  mozilla::SharedThreadPool::InitStatics();
+}
+
+void
+GeckoMedia_Shutdown()
+{
+  mozilla::Preferences::Shutdown();
+  NS_ShutdownXPCOM(nullptr);
+}

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -1,0 +1,16 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef GeckoMedia_h_
+#define GeckoMedia_h_
+
+void
+GeckoMedia_Initialize();
+
+void
+GeckoMedia_Shutdown();
+
+#endif // GeckoMedia_h_

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -13,4 +13,14 @@ GeckoMedia_Initialize();
 void
 GeckoMedia_Shutdown();
 
+enum CanPlayTypeResult
+{
+  No = 0,
+  Maybe = 1,
+  Probably = 2,
+};
+
+CanPlayTypeResult
+GeckoMedia_CanPlayType(const char* aMimeType);
+
 #endif // GeckoMedia_h_

--- a/gecko/glue/include/wrapper.hpp
+++ b/gecko/glue/include/wrapper.hpp
@@ -1,0 +1,1 @@
+#include "GeckoMedia.h"

--- a/gecko/test/test.cpp
+++ b/gecko/test/test.cpp
@@ -1,12 +1,15 @@
 #include <assert.h>
+#include <map>
 #include <stdio.h>
 #include <string.h>
 #include <string>
 #include <unistd.h>
-#include <map>
 
 #include "AudioStream.h"
 #include "GeckoMedia.h"
+#include "ImageContainer.h"
+#include "MediaData.h"
+#include "PlatformDecoderModule.h"
 #include "VideoUtils.h"
 #include "gecko_media_prefs.h"
 #include "mozilla/ArrayUtils.h"
@@ -23,9 +26,6 @@
 #include "nsTArray.h"
 #include "nsThreadManager.h"
 #include "nsThreadUtils.h"
-#include "MediaData.h"
-#include "ImageContainer.h"
-#include "PlatformDecoderModule.h"
 
 #define SIMPLE_STRING "I'm a simple ASCII string"
 #define UTF8_STRING                                                            \
@@ -86,19 +86,27 @@ std::map<const char*, bool> sBoolPrefs;
 std::map<const char*, int32_t> sIntPrefs;
 std::map<const char*, const char*> sStrPrefs;
 
-void pref(const char* aName, bool aValue) {
+void
+pref(const char* aName, bool aValue)
+{
   sBoolPrefs[aName] = aValue;
 }
 
-void pref(const char* aName, const char* aValue) {
+void
+pref(const char* aName, const char* aValue)
+{
   sStrPrefs[aName] = aValue;
 }
 
-void pref(const char* aName, int32_t aValue) {
+void
+pref(const char* aName, int32_t aValue)
+{
   sIntPrefs[aName] = aValue;
 }
 
-void InitPrefs() {
+void
+InitPrefs()
+{
 #include "../glue/prefs_common.cpp"
 #if defined(MOZ_WIDGET_ANDROID)
 #include "../glue/prefs_android.cpp"
@@ -330,8 +338,7 @@ TestTimeStamp()
 // Copy of BlankVideoDataCreator::Create(), use BlankVideoDataCreator
 // directly once it's in our source.
 already_AddRefed<MediaData>
-CreateBlankVideoData(uint32_t aFrameWidth,
-                     uint32_t aFrameHeight)
+CreateBlankVideoData(uint32_t aFrameWidth, uint32_t aFrameHeight)
 {
   // Create a fake YUV buffer in a 420 format. That is, an 8bpp Y plane,
   // with a U and V plane that are half the size of the Y plane, i.e 8 bit,
@@ -377,18 +384,20 @@ CreateBlankVideoData(uint32_t aFrameWidth,
   info.mDisplay = gfx::IntSize(aFrameWidth, aFrameHeight);
   gfx::IntRect picture(0, 0, aFrameWidth, aFrameHeight);
   RefPtr<layers::ImageContainer> imageContainer = new layers::ImageContainer();
-  return VideoData::CreateAndCopyData(info,
-                                      imageContainer,
-                                      0,
-                                      media::TimeUnit::Zero(),
-                                      media::TimeUnit::FromSeconds(1000.0 / 30.0),
-                                      buffer,
-                                      false,
-                                      media::TimeUnit::Zero(),
-                                      picture);
+  return VideoData::CreateAndCopyData(
+    info,
+    imageContainer,
+    0,
+    media::TimeUnit::Zero(),
+    media::TimeUnit::FromSeconds(1000.0 / 30.0),
+    buffer,
+    false,
+    media::TimeUnit::Zero(),
+    picture);
 }
 
-void TestVideoData()
+void
+TestVideoData()
 {
   RefPtr<MediaData> frame = CreateBlankVideoData(320, 240);
   assert(frame != nullptr);
@@ -408,11 +417,9 @@ CreateBlankAudioData()
 
   // Convert duration to frames. We add 1 to duration to account for
   // rounding errors, so we get a consistent tone.
-  CheckedInt64 frames = UsecsToFrames(
-    duration.ToMicroseconds()+1, sampleRate);
-  if (!frames.isValid() ||
-      !channelCount ||
-      !sampleRate ||
+  CheckedInt64 frames =
+    UsecsToFrames(duration.ToMicroseconds() + 1, sampleRate);
+  if (!frames.isValid() || !channelCount || !sampleRate ||
       frames.value() > (UINT32_MAX / channelCount)) {
     return nullptr;
   }
@@ -440,13 +447,15 @@ CreateBlankAudioData()
   return data.forget();
 }
 
-void TestAudioData()
+void
+TestAudioData()
 {
   RefPtr<MediaData> frame = CreateBlankAudioData();
   assert(frame != nullptr);
 }
 
-extern void Test_MediaMIMETypes();
+extern void
+Test_MediaMIMETypes();
 
 } // namespace mozilla
 

--- a/gecko/test/test.cpp
+++ b/gecko/test/test.cpp
@@ -6,6 +6,7 @@
 #include <map>
 
 #include "AudioStream.h"
+#include "GeckoMedia.h"
 #include "VideoUtils.h"
 #include "gecko_media_prefs.h"
 #include "mozilla/ArrayUtils.h"
@@ -452,13 +453,6 @@ extern void Test_MediaMIMETypes();
 extern "C" void
 TestGecko()
 {
-  // TODO: Move these Init calls to a top-level function? See also XPCOMInit.
-  mozilla::LogModule::Init();
-  NS_SetMainThread();
-  nsThreadManager::get().Init();
-  NS_InitMinimalXPCOM();
-  mozilla::SharedThreadPool::InitStatics();
-
   mozilla::TestPreferences();
   mozilla::TestString();
   mozilla::TestArray();
@@ -470,7 +464,4 @@ TestGecko()
   mozilla::TestVideoData();
   mozilla::TestAudioData();
   mozilla::Test_MediaMIMETypes();
-
-  mozilla::Preferences::Shutdown();
-  NS_ShutdownXPCOM(nullptr);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
 #[allow(unused_extern_crates)]
 #[cfg(feature = "pulseaudio")]
 extern crate cubeb_pulse;
@@ -15,16 +20,36 @@ pub use mime_parser_glue::mime_parser_get_param;
 pub use mime_parser_glue::mime_parser_free_string;
 pub use mime_parser_glue::mime_parser_get_type;
 
+
+/// Initialize Gecko Media. Must be called on the thread which Gecko will
+/// consider the "main" thread.
+pub fn initialize() {
+    unsafe {
+        GeckoMedia_Initialize();
+    }
+}
+
+/// Shutsdown Gecko Media.
+pub fn shutdown() {
+    unsafe {
+        GeckoMedia_Shutdown();
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     extern "C" {
         fn TestGecko();
     }
 
     #[test]
-    fn it_works() {
+    fn run_tests() {
+        initialize();
         unsafe {
             TestGecko();
         };
+        shutdown();
     }
 }


### PR DESCRIPTION
- Add Rust API for initialization, shutdown, and canPlayType.
- canPlayType always returns "can't play" for now.
- Used bindgen to generate wrappers for calling the gecko functions.