### PR TITLE
Try removing ccache and zlib brew install to see if it makes builds faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,9 @@ addons:
       - dbus-x11
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update;
-      brew install zlib ccache;
-      export PATH="/usr/local/opt/ccache/libexec:$PATH";
-    else
-      export PATH="/usr/lib/ccache/:$PATH";
-    fi;
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+  -   export PATH="/usr/lib/ccache/:$PATH";
+  - fi;
   - virtualenv ../venv
   - source ../venv/bin/activate
   - python --version


### PR DESCRIPTION
The purpose of this PR is to trigger a Travis job to see whether we can build if we don't install zlib and ccache via brew on OSX, and to see whether the build is faster.

It looks like we spend a whole bunch of time updating brew, just to install 2 packages (zlib & ccache), and it's not clear we even need zlib.

ccache may make the build faster, but if it takes us 20 minutes to install, we're losing.

If we need zlib and ccache, we could try precompiling or caching compiled packages, and using them instead.