### PR TITLE
Use the Rust message loop thread as the Gecko main thread

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,7 @@ fn compile_gecko_media() {
 }
 
 fn print_rerun_if() {
-   println!("cargo:rerun-if-changed=CMakeLists.txt");
+    println!("cargo:rerun-if-changed=CMakeLists.txt");
     for entry in WalkDir::new("gecko") {
         let entry = entry.unwrap();
         println!("cargo:rerun-if-changed={}", entry.path().display());

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -13,26 +13,100 @@
 #include "nsThreadManager.h"
 #include "nsThreadUtils.h"
 
-void
-GeckoMedia_Initialize()
+extern "C" void
+call_gecko_process_events(rust_msg_sender_t* aSender);
+extern "C" void
+free_gecko_process_events_sender(rust_msg_sender_t* aSender);
+
+static rust_msg_sender_t* sProcessEventsRustSender = nullptr;
+
+class GeckoMediaMainThreadObserver final : public nsIThreadObserver
 {
-  mozilla::LogModule::Init();
+public:
+  NS_DECL_THREADSAFE_ISUPPORTS
+
+  NS_IMETHOD OnDispatchedEvent(void) override
+  {
+    call_gecko_process_events(sProcessEventsRustSender);
+    return NS_OK;
+  }
+  NS_IMETHOD OnProcessNextEvent(nsIThreadInternal* thread,
+                                bool mayWait) override
+  {
+    return NS_OK;
+  }
+  NS_IMETHOD AfterProcessNextEvent(nsIThreadInternal* thread,
+                                   bool eventWasProcessed) override
+  {
+    return NS_OK;
+  }
+
+private:
+  ~GeckoMediaMainThreadObserver() {}
+};
+NS_IMPL_ISUPPORTS(GeckoMediaMainThreadObserver, nsIThreadObserver)
+
+static bool
+AddMainThreadObserver(rust_msg_sender_t* aSender)
+{
+  sProcessEventsRustSender = aSender;
+  nsCOMPtr<nsIThreadInternal> thread = do_QueryInterface(NS_GetCurrentThread());
+  return thread &&
+         NS_SUCCEEDED(thread->SetObserver(new GeckoMediaMainThreadObserver()));
+}
+
+bool
+GeckoMedia_Initialize(rust_msg_sender_t* aSender)
+{
   NS_SetMainThread();
-  nsThreadManager::get().Init();
-  NS_InitMinimalXPCOM();
+  if (NS_FAILED(nsThreadManager::get().Init())) {
+    return false;
+  }
+  mozilla::LogModule::Init();
+  if (NS_FAILED(NS_InitMinimalXPCOM())) {
+    return false;
+  }
+
   mozilla::SharedThreadPool::InitStatics();
   mozilla::MediaPrefs::GetSingleton();
+
+  // Add a thread observer so whenever runnables are dispatched
+  // to the main thread we can send a message to the Rust message
+  // loop to run the tasks on the Rust message loop thread. This
+  // ensures we use the Rust message loop as the Gecko "main"
+  // thread.
+  if (!AddMainThreadObserver(aSender)) {
+    return false;
+  }
+
+  // Run any events that were dispatched during initialization.
+  if (NS_FAILED(NS_ProcessPendingEvents(nullptr))) {
+    return false;
+  }
+
+  return true;
 }
 
 void
 GeckoMedia_Shutdown()
 {
+  MOZ_ASSERT(NS_IsMainThread());
+
   mozilla::Preferences::Shutdown();
   NS_ShutdownXPCOM(nullptr);
+
+  free_gecko_process_events_sender(sProcessEventsRustSender);
 }
 
 CanPlayTypeResult
 GeckoMedia_CanPlayType(const char* aMimeType)
 {
   return CanPlayTypeResult::No;
+}
+
+void
+GeckoMedia_ProcessEvents()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  NS_ProcessPendingEvents(nullptr);
 }

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -58,6 +58,11 @@ AddMainThreadObserver(rust_msg_sender_t* aSender)
 bool
 GeckoMedia_Initialize(rust_msg_sender_t* aSender)
 {
+  static bool initialized = false;
+  if (initialized) {
+    return true;
+  }
+  initialized = true;
   NS_SetMainThread();
   if (NS_FAILED(nsThreadManager::get().Init())) {
     return false;

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -9,8 +9,8 @@
 
 struct rust_msg_sender_t;
 
-void
-GeckoMedia_Initialize();
+bool
+GeckoMedia_Initialize(rust_msg_sender_t* aSender);
 
 void
 GeckoMedia_Shutdown();
@@ -24,5 +24,8 @@ enum CanPlayTypeResult
 
 CanPlayTypeResult
 GeckoMedia_CanPlayType(const char* aMimeType);
+
+void
+GeckoMedia_ProcessEvents();
 
 #endif // GeckoMedia_h_

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -7,6 +7,8 @@
 #ifndef GeckoMedia_h_
 #define GeckoMedia_h_
 
+struct rust_msg_sender_t;
+
 void
 GeckoMedia_Initialize();
 

--- a/gecko/test/test.cpp
+++ b/gecko/test/test.cpp
@@ -477,7 +477,10 @@ TestDecoderTraits()
 } // namespace mozilla
 
 extern "C" void
-TestGecko()
+finish_tests(rust_msg_sender_t* aSender);
+
+extern "C" void
+TestGecko(rust_msg_sender_t* aSender)
 {
   mozilla::TestPreferences();
   mozilla::TestString();
@@ -492,4 +495,9 @@ TestGecko()
   mozilla::Test_MediaMIMETypes();
   mozilla::Test_MP4Demuxer();
   mozilla::TestDecoderTraits();
+
+  RefPtr<mozilla::Runnable> task = NS_NewRunnableFunction(
+    "RustMessageDispatcher", [aSender]() { finish_tests(aSender); });
+  auto rv = NS_DispatchToMainThread(task.forget());
+  MOZ_ASSERT(NS_SUCCEEDED(rv));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,8 @@ pub mod bindings {
 pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use top::GeckoMedia;
 pub use top::finish_tests;
+pub use top::call_gecko_process_events;
+pub use top::free_gecko_process_events_sender;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod bindings {
 #[doc(inline)]
 pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use top::GeckoMedia;
+pub use top::finish_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@
 
 #[allow(unused_extern_crates)]
 extern crate cubeb_pulse;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 extern crate libc;
 extern crate mime;
 extern crate mp4parse_capi;

--- a/src/top.rs
+++ b/src/top.rs
@@ -3,8 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use CanPlayType;
-use bindings::{rust_msg_sender_t, GeckoMedia_CanPlayType, GeckoMedia_Initialize,
-               GeckoMedia_ProcessEvents, GeckoMedia_Shutdown};
+use bindings::*;
 use std::ffi::CString;
 use std::mem::transmute;
 use std::ops::Drop;


### PR DESCRIPTION
In order to prevent excessive shuffling of function calls between threads and synchronization, make Runnables dispatched to be run on Gecko's "main" thread run on the thread that the Rust GeckoMedia code creates for receiving and processing messages. To achieve this, we pass a pointers to a mspc::Sender over to the C++ code, and when the C++ code needs to run tasks on the "main" thread, it calls a Rust function over FFI that causes the Sender to have the appropriate message sent on it. When the Rust message loop processes that message, it will call back into Gecko/C++ on the Rust message loop thread, and run Gecko "main" thread Runnables.