### PR TITLE
Beginnings of Servo -> MediaDecoder interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ add_library(gecko_core OBJECT
   gecko/glue/FFmpegRuntimeLinker.cpp
   gecko/glue/GeckoMedia.cpp
   gecko/glue/MediaDecoderFFI.cpp
+  gecko/glue/RustFunctions.cpp
   gecko/glue/ImageContainer.cpp
   gecko/glue/InputEventStatistics.cpp
   gecko/glue/nsDebugImpl.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ add_library(gecko_core OBJECT
   gecko/glue/DecoderTraits.cpp
   gecko/glue/FFmpegRuntimeLinker.cpp
   gecko/glue/GeckoMedia.cpp
+  gecko/glue/MediaDecoderFFI.cpp
   gecko/glue/ImageContainer.cpp
   gecko/glue/InputEventStatistics.cpp
   gecko/glue/nsDebugImpl.cpp

--- a/build.rs
+++ b/build.rs
@@ -37,8 +37,15 @@ fn compile_gecko_media() {
     println!("cargo:rustc-link-lib=dl");
     #[cfg(target_os = "macos")]
     {
-        let frameworks = vec!["CoreFoundation", "CoreAudio", "AudioUnit", "AudioToolbox",
-                              "AVFoundation", "CoreVideo", "VideoToolbox"];
+        let frameworks = vec![
+            "CoreFoundation",
+            "CoreAudio",
+            "AudioUnit",
+            "AudioToolbox",
+            "AVFoundation",
+            "CoreVideo",
+            "VideoToolbox",
+        ];
         for framework in &frameworks {
             println!("cargo:rustc-link-lib=framework={}", framework);
         }

--- a/gecko/glue/MediaDecoderFFI.cpp
+++ b/gecko/glue/MediaDecoderFFI.cpp
@@ -1,0 +1,37 @@
+#include "MediaDecoderFFI.h"
+#include <unordered_map>
+
+#include "mozilla/Assertions.h"
+#include "mozilla/Range.h"
+#include "nsThreadUtils.h"
+
+static std::unordered_map<size_t, mozilla::Range<const uint8_t>> sBlobs;
+
+void
+MediaDecoder_Load(size_t aId,
+                  const uint8_t* aData,
+                  size_t aDataLength,
+                  const char* aMimeType)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  // TODO: Create decoder for aData.
+  // TODO: Ensure decoder owns aData, rather than storing it in sBlobs.
+  sBlobs.insert({ aId, mozilla::Range<const uint8_t>(aData, aDataLength) });
+}
+
+extern "C" void
+free_rust_vec_u8(const uint8_t* aVec, size_t aLength);
+
+void
+MediaDecoder_Unload(size_t aId)
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  // TODO: GetDecoder(aId)->Shutdown();
+  // TODO: Release reference to data in MediaDecoder destructor.
+  auto itr = sBlobs.find(aId);
+  if (itr != sBlobs.end()) {
+    mozilla::Range<const uint8_t> r = itr->second;
+    sBlobs.erase(itr);
+    free_rust_vec_u8(r.begin().get(), r.length());
+  }
+}

--- a/gecko/glue/MediaDecoderFFI.cpp
+++ b/gecko/glue/MediaDecoderFFI.cpp
@@ -1,9 +1,9 @@
 #include "MediaDecoderFFI.h"
-#include <unordered_map>
-
+#include "RustFunctions.h"
 #include "mozilla/Assertions.h"
 #include "mozilla/Range.h"
 #include "nsThreadUtils.h"
+#include <unordered_map>
 
 static std::unordered_map<size_t, mozilla::Range<const uint8_t>> sBlobs;
 
@@ -19,9 +19,6 @@ MediaDecoder_Load(size_t aId,
   sBlobs.insert({ aId, mozilla::Range<const uint8_t>(aData, aDataLength) });
 }
 
-extern "C" void
-free_rust_vec_u8(const uint8_t* aVec, size_t aLength);
-
 void
 MediaDecoder_Unload(size_t aId)
 {
@@ -32,6 +29,6 @@ MediaDecoder_Unload(size_t aId)
   if (itr != sBlobs.end()) {
     mozilla::Range<const uint8_t> r = itr->second;
     sBlobs.erase(itr);
-    free_rust_vec_u8(r.begin().get(), r.length());
+    FreeRustVecU8(r.begin().get(), r.length());
   }
 }

--- a/gecko/glue/RustFunctions.cpp
+++ b/gecko/glue/RustFunctions.cpp
@@ -1,0 +1,32 @@
+#include "RustFunctions.h"
+#include "mozilla/Assertions.h"
+
+static const RustFunctions* sRustFunctions = nullptr;
+
+void
+InitializeRustFunctions(const RustFunctions* aFunctions)
+{
+  MOZ_ASSERT(!sRustFunctions);
+  sRustFunctions = aFunctions;
+}
+
+void
+CallGeckoProcessEvents(rust_msg_sender_t* aSender)
+{
+  MOZ_ASSERT(sRustFunctions);
+  sRustFunctions->CallGeckoProcessEvents(aSender);
+}
+
+void
+FreeProcessEventsSender(rust_msg_sender_t* aSender)
+{
+  MOZ_ASSERT(sRustFunctions);
+  sRustFunctions->FreeProcessEventsSender(aSender);
+}
+
+void
+FreeRustVecU8(const uint8_t* aVec, size_t aLength)
+{
+  MOZ_ASSERT(sRustFunctions);
+  sRustFunctions->FreeRustVecU8(aVec, aLength);
+}

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -11,8 +11,16 @@
 
 struct rust_msg_sender_t;
 
+struct RustFunctions
+{
+  void (*CallGeckoProcessEvents)(rust_msg_sender_t*);
+  void (*FreeProcessEventsSender)(rust_msg_sender_t*);
+  void (*FreeRustVecU8)(const uint8_t*, size_t);
+};
+
 bool
-GeckoMedia_Initialize(rust_msg_sender_t* aSender);
+GeckoMedia_Initialize(const RustFunctions* aFunctions,
+                      rust_msg_sender_t* aSender);
 
 void
 GeckoMedia_Shutdown();

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -7,6 +7,8 @@
 #ifndef GeckoMedia_h_
 #define GeckoMedia_h_
 
+#include "MediaDecoderFFI.h"
+
 struct rust_msg_sender_t;
 
 bool
@@ -30,8 +32,8 @@ GeckoMedia_ProcessEvents();
 
 struct RustRunnable
 {
-  void *data;
-  void (*function)(void *data);
+  void* data;
+  void (*function)(void* data);
 };
 
 void

--- a/gecko/glue/include/MediaDecoderFFI.h
+++ b/gecko/glue/include/MediaDecoderFFI.h
@@ -1,0 +1,22 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MediaDecoderFFI_h_
+#define MediaDecoderFFI_h_
+
+#include <stddef.h>
+#include <stdint.h>
+
+void
+MediaDecoder_Load(size_t aId,
+                  const uint8_t* aData,
+                  size_t aDataLength,
+                  const char* aMimeType);
+
+void
+MediaDecoder_Unload(size_t aId);
+
+#endif // MediaDecoderFFI_h_

--- a/gecko/glue/include/RustFunctions.h
+++ b/gecko/glue/include/RustFunctions.h
@@ -1,0 +1,24 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef RustFunctions_h_
+#define RustFunctions_h_
+
+#include "GeckoMedia.h"
+
+void
+InitializeRustFunctions(const RustFunctions* aFunctions);
+
+void
+CallGeckoProcessEvents(rust_msg_sender_t* aSender);
+
+void
+FreeProcessEventsSender(rust_msg_sender_t* aSender);
+
+void
+FreeRustVecU8(const uint8_t* aVec, size_t aLength);
+
+#endif // RustFunctions_h_

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,6 @@ pub mod bindings {
 #[doc(inline)]
 pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use top::GeckoMedia;
-pub use top::call_gecko_process_events;
-pub use top::free_gecko_process_events_sender;
-pub use top::free_rust_vec_u8;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,9 @@ mod tests {
         test_can_play_type();
         GeckoMedia::get().unwrap().test();
         let (sender, receiver) = mpsc::channel();
-        GeckoMedia::get().unwrap().queue_task(move || sender.send(()).unwrap());
+        GeckoMedia::get()
+            .unwrap()
+            .queue_task(move || sender.send(()).unwrap());
         receiver.recv().unwrap();
         GeckoMedia::shutdown().unwrap();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use top::GeckoMedia;
 pub use top::call_gecko_process_events;
 pub use top::free_gecko_process_events_sender;
+pub use top::free_rust_vec_u8;
 
 #[cfg(test)]
 mod tests {

--- a/src/top.rs
+++ b/src/top.rs
@@ -14,14 +14,16 @@ use std::thread::Builder;
 
 pub struct GeckoMedia {
     sender: Sender<GeckoMediaMsg>,
+    id: usize,
 }
 
 impl GeckoMedia {
     pub fn get() -> Result<Self, ()> {
         OUTSTANDING_HANDLES.fetch_add(1, Ordering::SeqCst);
+        let id = INSTANCE_COUNT.fetch_add(1, Ordering::SeqCst);
         let sender = SENDER.lock().unwrap();
         match sender.clone() {
-            Some(sender) => Ok(GeckoMedia { sender }),
+            Some(sender) => Ok(GeckoMedia { sender, id }),
             None => {
                 OUTSTANDING_HANDLES.fetch_sub(1, Ordering::SeqCst);
                 Err(())
@@ -95,6 +97,7 @@ enum GeckoMediaMsg {
 }
 
 static OUTSTANDING_HANDLES: AtomicUsize = ATOMIC_USIZE_INIT;
+static INSTANCE_COUNT: AtomicUsize = ATOMIC_USIZE_INIT;
 
 lazy_static! {
     static ref SENDER: Mutex<Option<Sender<GeckoMediaMsg>>> = {


### PR DESCRIPTION
This isn't quite complete, but I'm requesting merge, as otherwise everyone else will also need to rewrite this code in order to get anything done.

- Adds an id to each instance of GeckoMedia. We'll use this id to uniquely identify MediaDecoder instances on the C++ side of the FFI boundary.
- In future when a GeckoMedia instance needs to call a function on a MediaDecoder instance, it must pass the id over the FFI boundary, and the C++ code can lookup the instance using the id in a hash table or somesuch, and call the corresponding function (this code isn't there yet).
- Adds MediaDecoder_Load() and MediaDecoder_Unload() C functions which internal Rust code can call. These assume we're passed a Vec<u8> to play, as what Servo can pass for BlobURIs today.
- Switch to passing a table of functions over the FFI boundary rather than declaring every Rust function we want C++ to be able to call as "pub".
