### PR TITLE
Player

### DIFF
--- a/gecko/glue/XPCOMInit.cpp
+++ b/gecko/glue/XPCOMInit.cpp
@@ -18,6 +18,7 @@
 #include "mozilla/ClearOnShutdown.h"
 #include "mozilla/Module.h"
 #include "mozilla/ModuleUtils.h"
+#include "mozilla/SystemGroup.h"
 
 bool gXPCOMThreadsShutDown = false;
 bool gXPCOMShuttingDown = false;
@@ -103,6 +104,9 @@ NS_InitMinimalXPCOM()
     NS_RELEASE(nsComponentManagerImpl::gComponentManager);
     return rv;
   }
+
+  // Init the SystemGroup for dispatching main thread runnables.
+  SystemGroup::InitStatic();
 
   // Set up the timer globals/timer thread.
   rv = nsTimerImpl::Startup();

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -9,13 +9,14 @@
 
 struct ThreadObserverVtable
 {
-  void (*mOnDispatchedEvent)(void *aData);
-  void (*mFree)(void *aData);
+  void (*mOnDispatchedEvent)(void* aData);
+  void (*mFree)(void* aData);
 };
 
-struct ThreadObserverObject {
-  void *mData;
-  const ThreadObserverVtable *mVtable;
+struct ThreadObserverObject
+{
+  void* mData;
+  const ThreadObserverVtable* mVtable;
 };
 
 bool
@@ -39,8 +40,8 @@ GeckoMedia_ProcessEvents();
 
 struct RustRunnable
 {
-  void *mData;
-  void (*mFunction)(void *aData);
+  void* mData;
+  void (*mFunction)(void* aData);
 };
 
 void

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -52,9 +52,9 @@ GeckoMedia_QueueRustRunnable(RustRunnable aRunnable);
 
 struct RustVecU8Object
 {
-  const uint8_t* mData;
+  uint8_t* mData;
   size_t mLength;
-  void (*mFree)(const uint8_t* mData, size_t aLength);
+  void (*mFree)(uint8_t* mData, size_t aLength);
 };
 
 struct PlayerCallbackObject

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -7,6 +7,9 @@
 #ifndef GeckoMedia_h_
 #define GeckoMedia_h_
 
+#include <stddef.h>
+#include <stdint.h>
+
 struct ThreadObserverVtable
 {
   void (*mOnDispatchedEvent)(void* aData);
@@ -46,5 +49,37 @@ struct RustRunnable
 
 void
 GeckoMedia_QueueRustRunnable(RustRunnable aRunnable);
+
+struct RustVecU8Object
+{
+  const uint8_t* mData;
+  size_t mLength;
+  void (*mFree)(const uint8_t* mData, size_t aLength);
+};
+
+struct PlayerCallbackObject
+{
+  void* mContext;
+  void (*mPlaybackEnded)(void*);
+  void (*mDecodeError)(void*);
+  void (*mFree)(void*);
+};
+
+void
+GeckoMedia_Player_Create(size_t aId, PlayerCallbackObject aCallback);
+
+void
+GeckoMedia_Player_LoadBlob(size_t aId,
+                           RustVecU8Object aMediaData,
+                           const char* aMimeType);
+
+void
+GeckoMedia_Player_Play(size_t aId);
+
+void
+GeckoMedia_Player_Pause(size_t aId);
+
+void
+GeckoMedia_Player_Shutdown(size_t aId);
 
 #endif // GeckoMedia_h_

--- a/gecko/test/test.cpp
+++ b/gecko/test/test.cpp
@@ -525,7 +525,7 @@ TestGeckoDecoder()
 {
   GeckoMediaDecoderOwner owner;
   MediaDecoderInit decoderInit(&owner,
-                               0.05,  // volume
+                               0.001,  // volume
                                true,  // mPreservesPitch
                                1.0,   // mPlaybackRate
                                false, // mMinimizePreroll

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,10 @@ pub use top::PlayerEventSink;
 
 #[cfg(test)]
 mod tests {
-    use std::sync::mpsc;
-    use {CanPlayType, GeckoMedia, PlayerEventSink};
     use std::fs::File;
     use std::io::prelude::*;
+    use std::sync::mpsc;
+    use {CanPlayType, GeckoMedia, PlayerEventSink};
 
     fn test_can_play_type() {
         let gecko_media = GeckoMedia::get().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,15 @@ pub mod bindings {
 #[doc(inline)]
 pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use top::GeckoMedia;
+pub use top::Player;
+pub use top::PlayerEventSink;
 
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;
-    use {CanPlayType, GeckoMedia};
+    use {CanPlayType, GeckoMedia, PlayerEventSink};
+    use std::fs::File;
+    use std::io::prelude::*;
 
     fn test_can_play_type() {
         let gecko_media = GeckoMedia::get().unwrap();
@@ -44,8 +48,45 @@ mod tests {
         test_can_play_type();
         GeckoMedia::get().unwrap().test();
         let (sender, receiver) = mpsc::channel();
-        GeckoMedia::get().unwrap().queue_task(move || sender.send(()).unwrap());
+        GeckoMedia::get().unwrap().queue_task(
+            move || sender.send(()).unwrap(),
+        );
         receiver.recv().unwrap();
+        {
+            enum Status {
+                Error,
+                Ended,
+            }
+            let (sender, receiver) = mpsc::channel();
+            struct Sink {
+                sender: mpsc::Sender<Status>,
+            }
+            impl PlayerEventSink for Sink {
+                fn playback_ended(&self) {
+                    self.sender.send(Status::Ended).unwrap();
+                }
+                fn decode_error(&self) {
+                    self.sender.send(Status::Error).unwrap();
+                }
+            }
+            let sink = Box::new(Sink { sender: sender });
+
+            let g = GeckoMedia::get().unwrap();
+            let player = g.create_player(sink).unwrap();
+            let mut file = File::open("gecko/test/audiotest.wav").unwrap();
+            let mut bytes = vec![];
+            file.read_to_end(&mut bytes).unwrap();
+            player.load_blob(bytes, "audio/wav").unwrap();
+            player.play();
+
+            let ok = match receiver.recv().unwrap() {
+                Status::Ended => true,
+                Status::Error => false,
+            };
+            assert!(ok);
+            player.shutdown();
+        }
+
         GeckoMedia::shutdown().unwrap();
     }
 }

--- a/src/top.rs
+++ b/src/top.rs
@@ -5,6 +5,7 @@
 use CanPlayType;
 use bindings::*;
 use std::ffi::CString;
+use std::mem;
 use std::ops::Drop;
 use std::os::raw::c_void;
 use std::sync::Mutex;
@@ -14,6 +15,45 @@ use std::thread::Builder;
 
 pub struct GeckoMedia {
     sender: Sender<GeckoMediaMsg>,
+}
+
+pub struct Player {
+    gecko_media: GeckoMedia,
+    id: usize,
+}
+
+pub trait PlayerEventSink {
+    fn playback_ended(&self);
+    fn decode_error(&self);
+}
+
+impl Player {
+    pub fn load_blob(&self, media_data: Vec<u8>, mime_type: &str) -> Result<(), ()> {
+        let media_data = to_ffi_vec(media_data);
+        let mime_type = match CString::new(mime_type.as_bytes()) {
+            Ok(mime_type) => mime_type,
+            _ => return Err(()),
+        };
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_Player_LoadBlob(self.id, media_data, mime_type.as_ptr());
+        });
+        Ok(())
+    }
+    pub fn play(&self) {
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_Player_Play(self.id);
+        });
+    }
+    pub fn pause(&self) {
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_Player_Pause(self.id);
+        });
+    }
+    pub fn shutdown(&self) {
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_Player_Shutdown(self.id);
+        });
+    }
 }
 
 impl GeckoMedia {
@@ -59,7 +99,7 @@ impl GeckoMedia {
     where
         F: FnOnce(),
     {
-        unsafe extern fn call<F>(ptr: *mut c_void)
+        unsafe extern "C" fn call<F>(ptr: *mut c_void)
         where
             F: FnOnce(),
         {
@@ -72,6 +112,46 @@ impl GeckoMedia {
         };
 
         unsafe { GeckoMedia_QueueRustRunnable(runnable) }
+    }
+
+    pub fn create_player(&self, sink: Box<PlayerEventSink>) -> Result<Player, ()> {
+        let handle = GeckoMedia::get()?;
+        let id = NEXT_PLAYER_ID.fetch_add(1, Ordering::SeqCst);
+
+        let callback = self.to_ffi_callback(sink);
+        self.queue_task(move || unsafe {
+            GeckoMedia_Player_Create(id, callback);
+        });
+
+        Ok(Player {
+            gecko_media: handle,
+            id,
+        })
+    }
+
+    fn to_ffi_callback(&self, sink: Box<PlayerEventSink>) -> PlayerCallbackObject {
+        // Can't cast from *c_void to a Trait, so wrap in a concrete type
+        // when we pass into C++ code.
+        struct Wrapper {
+            sink: Box<PlayerEventSink>,
+        }
+        unsafe extern "C" fn free(ptr: *mut c_void) {
+            drop(Box::from_raw(ptr as *mut Wrapper));
+        }
+        unsafe extern "C" fn decode_error(ptr: *mut c_void) {
+            let wrapper = &*(ptr as *mut Wrapper);
+            wrapper.sink.decode_error();
+        }
+        unsafe extern "C" fn playback_ended(ptr: *mut c_void) {
+            let wrapper = &*(ptr as *mut Wrapper);
+            wrapper.sink.playback_ended();
+        }
+        PlayerCallbackObject {
+            mContext: Box::into_raw(Box::new(Wrapper { sink: sink })) as *mut c_void,
+            mPlaybackEnded: Some(playback_ended),
+            mDecodeError: Some(decode_error),
+            mFree: Some(free),
+        }
     }
 
     #[cfg(test)]
@@ -95,6 +175,7 @@ enum GeckoMediaMsg {
 }
 
 static OUTSTANDING_HANDLES: AtomicUsize = ATOMIC_USIZE_INIT;
+static NEXT_PLAYER_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
 lazy_static! {
     static ref SENDER: Mutex<Option<Sender<GeckoMediaMsg>>> = {
@@ -142,12 +223,12 @@ lazy_static! {
 }
 
 fn thread_observer_object(sender: Sender<GeckoMediaMsg>) -> ThreadObserverObject {
-    unsafe extern fn on_dispatched_event(ptr: *mut c_void) {
+    unsafe extern "C" fn on_dispatched_event(ptr: *mut c_void) {
         let sender = &*(ptr as *const Sender<GeckoMediaMsg>);
         sender.send(GeckoMediaMsg::CallProcessGeckoEvents).unwrap();
     }
 
-    unsafe extern fn free(ptr: *mut c_void) {
+    unsafe extern "C" fn free(ptr: *mut c_void) {
         drop(Box::from_raw(ptr as *mut Sender<GeckoMediaMsg>));
     }
 
@@ -159,5 +240,19 @@ fn thread_observer_object(sender: Sender<GeckoMediaMsg>) -> ThreadObserverObject
     ThreadObserverObject {
         mData: Box::into_raw(Box::new(sender)) as *mut c_void,
         mVtable: &VTABLE,
+    }
+}
+
+fn to_ffi_vec(v: Vec<u8>) -> RustVecU8Object {
+    unsafe extern "C" fn free(ptr: *const u8, len: usize) {
+        drop(Vec::from_raw_parts(ptr as *mut u8, len, len));
+    }
+    let data = v.as_ptr();
+    let len = v.len();
+    mem::forget(v);
+    RustVecU8Object {
+        mData: data,
+        mLength: len,
+        mFree: Some(free),
     }
 }


### PR DESCRIPTION
- A Player Rust object can be created using the GeckoMedia Rust object. This represents the player of a media file/stream. Currently only play, pause, and shutdown is implemented.
- The creator of the Player passes in an implementation of the Rust PlayerEventSink trait.
- The gecko-media calls back the PlayerEventSink trait to report events. Currently decode errors and playback ended is reported.
- Calls to the PlayerEventSink trait run on the "gecko main" thread.
- I expect Servo's PlayerEventSink implementation will queue a task (or dispatch a message through a channel?) to affect the appropriate action on the relevant script thread.
- Includes tests that the Rust Player and PlayerEventSink works. Plays at very low volume.