### PR TITLE
Binding for a few more Player features

### DIFF
--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -287,3 +287,13 @@ GeckoMedia_Player_SetVolume(size_t aId, double volume)
   }
   player->mDecoder->SetVolume(volume);
 }
+
+double
+GeckoMedia_Player_GetDuration(size_t aId)
+{
+  Player* player = GetPlayer(aId);
+  if (!player) {
+    return 0.0;
+  }
+  return player->mDecoder->GetDuration();
+}

--- a/gecko/glue/GeckoMediaDecoder.cpp
+++ b/gecko/glue/GeckoMediaDecoder.cpp
@@ -101,6 +101,16 @@ GeckoMediaDecoder::CanPlayThroughImpl()
   return true;
 }
 
+double
+GeckoMediaDecoder::GetDuration()
+{
+  if (mInfo && mInfo->mMetadataDuration.isSome()) {
+    return mInfo->mMetadataDuration.value().ToSeconds();
+  } else {
+    return MediaDecoder::GetDuration();
+  }
+}
+
 TimeInterval
 GeckoMediaDecoder::ClampIntervalToEnd(const TimeInterval& aInterval)
 {

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -62,6 +62,8 @@ struct PlayerCallbackObject
   void* mContext;
   void (*mPlaybackEnded)(void*);
   void (*mDecodeError)(void*);
+  void (*mAsyncEvent)(void*, const int8_t*);
+  void (*mMetadataLoaded)(void*);
   void (*mFree)(void*);
 };
 
@@ -84,5 +86,8 @@ GeckoMedia_Player_Shutdown(size_t aId);
 
 void
 GeckoMedia_Player_SetVolume(size_t aId, double volume);
+
+double
+GeckoMedia_Player_GetDuration(size_t aId);
 
 #endif // GeckoMedia_h_

--- a/gecko/glue/include/GeckoMediaDecoder.h
+++ b/gecko/glue/include/GeckoMediaDecoder.h
@@ -10,6 +10,7 @@
 #include "BufferMediaResource.h"
 #include "MediaDecoder.h"
 #include "mozilla/RefPtr.h"
+#include "TimeUnits.h"
 
 namespace mozilla {
 
@@ -29,6 +30,8 @@ public:
   bool IsTransportSeekable() override { return true; }
 
   void AddSizeOfResources(ResourceSizes* aSizes) override;
+
+  virtual double GetDuration() override;
 
 protected:
   RefPtr<BufferMediaResource> mResource;

--- a/gecko/glue/include/GeckoMediaDecoderOwner.h
+++ b/gecko/glue/include/GeckoMediaDecoderOwner.h
@@ -10,6 +10,7 @@
 #include "MediaDecoderOwner.h"
 #include "MediaInfo.h"
 #include "mozilla/UniquePtr.h"
+#include "nsAString.h"
 
 namespace mozilla {
 
@@ -47,6 +48,11 @@ public:
   // Dispatch an asynchronous event to the decoder owner
   virtual nsresult DispatchAsyncEvent(const nsAString& aName) override
   {
+    nsAutoCString dst;
+    CopyUTF16toUTF8(aName, dst);
+    if (mCallback.mContext && mCallback.mAsyncEvent) {
+      (*mCallback.mAsyncEvent)(mCallback.mContext, (const int8_t*) dst.get());
+    }
     return NS_OK;
   };
 
@@ -71,6 +77,10 @@ public:
   virtual void MetadataLoaded(const MediaInfo* aInfo,
                               UniquePtr<const MetadataTags> aTags) override
   {
+    // FIXME: serialize aInfo and aTags somehow to callback.
+    if (mCallback.mContext && mCallback.mMetadataLoaded) {
+      (*mCallback.mMetadataLoaded)(mCallback.mContext);
+    }
   }
 
   // Called by the decoder object, on the main thread,


### PR DESCRIPTION
This patch adds support for duration retrieval, (very) basic metadata-loaded
notification and async-event notification.