### PR TITLE
Connect timeupdate, seeking, and duration change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ add_library(gecko_core OBJECT
   gecko/glue/FFmpegRuntimeLinker.cpp
   gecko/glue/GeckoMedia.cpp
   gecko/glue/GeckoMediaDecoder.cpp
+  gecko/glue/GeckoMediaDecoderOwner.cpp
   gecko/glue/ImageContainer.cpp
   gecko/glue/InputEventStatistics.cpp
   gecko/glue/nsDebugImpl.cpp

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -287,13 +287,3 @@ GeckoMedia_Player_SetVolume(size_t aId, double volume)
   }
   player->mDecoder->SetVolume(volume);
 }
-
-double
-GeckoMedia_Player_GetDuration(size_t aId)
-{
-  Player* player = GetPlayer(aId);
-  if (!player) {
-    return 0.0;
-  }
-  return player->mDecoder->GetDuration();
-}

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -206,26 +206,18 @@ GetPlayer(size_t aId)
 }
 
 void
-GeckoMedia_Player_Create(size_t aId, PlayerCallbackObject aCallback)
-{
-  Player* player = sPlayers.AppendElement(Player(aId, aCallback));
-  MOZ_ASSERT(GetPlayer(aId) == player);
-}
-
-void
-GeckoMedia_Player_LoadBlob(size_t aId,
-                           RustVecU8Object aMediaData,
-                           const char* aMimeType)
+GeckoMedia_Player_CreateBlobPlayer(size_t aId,
+                                   RustVecU8Object aMediaData,
+                                   const char* aMimeType,
+                                   PlayerCallbackObject aCallback)
 {
   mozilla::Maybe<MediaContainerType> mime = MakeMediaContainerType(aMimeType);
   if (!mime) {
     return;
   }
 
-  Player* player = GetPlayer(aId);
-  if (!player) {
-    return;
-  }
+  Player* player = sPlayers.AppendElement(Player(aId, aCallback));
+  MOZ_ASSERT(GetPlayer(aId) == player);
 
   MediaDecoderInit decoderInit(player->mDecoderOwner.get(),
                                1.0,   // volume

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -228,7 +228,7 @@ GeckoMedia_Player_LoadBlob(size_t aId,
   }
 
   MediaDecoderInit decoderInit(player->mDecoderOwner.get(),
-                               0.001, // volume
+                               1.0,   // volume
                                true,  // mPreservesPitch
                                1.0,   // mPlaybackRate
                                false, // mMinimizePreroll

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -263,6 +263,17 @@ GeckoMedia_Player_Pause(size_t aId)
 }
 
 void
+GeckoMedia_Player_Seek(size_t aId, double aTimeOffsetSeconds)
+{
+  Player* player = GetPlayer(aId);
+  if (!player) {
+    return;
+  }
+  MOZ_ASSERT(player->mDecoder);
+  player->mDecoder->Seek(aTimeOffsetSeconds, SeekTarget::Accurate);
+}
+
+void
 GeckoMedia_Player_Shutdown(size_t aId)
 {
   Player* player = GetPlayer(aId);

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -236,7 +236,7 @@ GeckoMedia_Player_LoadBlob(size_t aId,
                                false, // mLooping
                                mime.value());
   player->mDecoder = new GeckoMediaDecoder(decoderInit);
-
+  player->mDecoderOwner->SetDecoder(player->mDecoder);
   RefPtr<BufferMediaResource> resource =
     new RustVecU8BufferMediaResource(aMediaData);
   player->mDecoder->Load(resource);

--- a/gecko/glue/GeckoMediaDecoder.cpp
+++ b/gecko/glue/GeckoMediaDecoder.cpp
@@ -34,7 +34,6 @@ namespace mozilla {
 
 GeckoMediaDecoder::GeckoMediaDecoder(MediaDecoderInit& aInit)
   : MediaDecoder(aInit)
-  , mEnded(false)
 {
   mExplicitDuration.emplace(UnspecifiedNaN<double>());
 }

--- a/gecko/glue/GeckoMediaDecoder.cpp
+++ b/gecko/glue/GeckoMediaDecoder.cpp
@@ -6,20 +6,27 @@
 #include "GeckoMediaDecoder.h"
 
 #include "DecoderTraits.h"
-#include "mozilla/Logging.h"
 #include "MediaDecoderStateMachine.h"
 #include "MediaShutdownManager.h"
 #include "VideoUtils.h"
+#include "mozilla/Logging.h"
 #include <algorithm>
 
-mozilla::LogModule* GetGeckoMediaLog()
+mozilla::LogModule*
+GetGeckoMediaLog()
 {
   static mozilla::LazyLogModule sLogModule("GeckoMedia");
   return sLogModule;
 }
 
-#define GECKO_DEBUG(arg, ...) MOZ_LOG(GetGeckoMediaLog(), mozilla::LogLevel::Debug, ("GeckoMediaDecoder(%p)::%s: " arg, this, __func__, ##__VA_ARGS__))
-#define GECKO_DEBUGV(arg, ...) MOZ_LOG(GetGeckoMediaLog(), mozilla::LogLevel::Verbose, ("GeckoMediaDecoder(%p)::%s: " arg, this, __func__, ##__VA_ARGS__))
+#define GECKO_DEBUG(arg, ...)                                                  \
+  MOZ_LOG(GetGeckoMediaLog(),                                                  \
+          mozilla::LogLevel::Debug,                                            \
+          ("GeckoMediaDecoder(%p)::%s: " arg, this, __func__, ##__VA_ARGS__))
+#define GECKO_DEBUGV(arg, ...)                                                 \
+  MOZ_LOG(GetGeckoMediaLog(),                                                  \
+          mozilla::LogLevel::Verbose,                                          \
+          ("GeckoMediaDecoder(%p)::%s: " arg, this, __func__, ##__VA_ARGS__))
 
 using namespace mozilla::media;
 
@@ -121,9 +128,8 @@ GeckoMediaDecoder::ClampIntervalToEnd(const TimeInterval& aInterval)
   if (duration < aInterval.mStart) {
     return aInterval;
   }
-  return TimeInterval(aInterval.mStart,
-                      std::min(aInterval.mEnd, duration),
-                      aInterval.mFuzz);
+  return TimeInterval(
+    aInterval.mStart, std::min(aInterval.mEnd, duration), aInterval.mFuzz);
 }
 
 already_AddRefed<nsIPrincipal>

--- a/gecko/glue/GeckoMediaDecoder.cpp
+++ b/gecko/glue/GeckoMediaDecoder.cpp
@@ -118,6 +118,26 @@ GeckoMediaDecoder::GetDuration()
   }
 }
 
+void
+GeckoMediaDecoder::Pause()
+{
+  mOwnerPaused = true;
+  MediaDecoder::Pause();
+}
+
+nsresult
+GeckoMediaDecoder::Play()
+{
+  mOwnerPaused = false;
+  return MediaDecoder::Play();
+}
+
+bool
+GeckoMediaDecoder::IsOwnerPaused() const
+{
+  return mOwnerPaused;
+}
+
 TimeInterval
 GeckoMediaDecoder::ClampIntervalToEnd(const TimeInterval& aInterval)
 {

--- a/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -31,6 +31,12 @@ GeckoMediaDecoderOwner::DispatchAsyncEvent(const nsAString& aName)
 {
   nsAutoCString dst;
   CopyUTF16toUTF8(aName, dst);
+  if (dst.EqualsLiteral("durationchange")) {
+    if (mCallback.mContext && mCallback.mDurationChanged) {
+      (*mCallback.mDurationChanged)(mCallback.mContext, mDecoder->GetDuration());
+      return NS_OK;
+    }
+  }
   if (mCallback.mContext && mCallback.mAsyncEvent) {
     (*mCallback.mAsyncEvent)(mCallback.mContext, (const int8_t*)dst.get());
   }
@@ -63,7 +69,9 @@ GeckoMediaDecoderOwner::MetadataLoaded(const MediaInfo* aInfo,
 {
   // FIXME: serialize aInfo and aTags somehow to callback.
   if (mCallback.mContext && mCallback.mMetadataLoaded) {
-    (*mCallback.mMetadataLoaded)(mCallback.mContext);
+    GeckoMediaMetadata metadata = { 0 };
+    metadata.mDuration = mDecoder->GetDuration();
+    (*mCallback.mMetadataLoaded)(mCallback.mContext, metadata);
   }
 }
 

--- a/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -45,6 +45,10 @@ GeckoMediaDecoderOwner::UpdateReadyState()
 void
 GeckoMediaDecoderOwner::FireTimeUpdate(bool aPeriodic)
 {
+  if (mCallback.mContext && mCallback.mTimeUpdate) {
+    double time = mDecoder->GetCurrentTime();
+    (*mCallback.mTimeUpdate)(mCallback.mContext, time);
+  }
 }
 
 bool
@@ -66,6 +70,9 @@ GeckoMediaDecoderOwner::MetadataLoaded(const MediaInfo* aInfo,
 void
 GeckoMediaDecoderOwner::FirstFrameLoaded()
 {
+  if (mCallback.mContext && mCallback.mLoadedData) {
+    (*mCallback.mLoadedData)(mCallback.mContext);
+  }
 }
 
 void
@@ -109,11 +116,17 @@ GeckoMediaDecoderOwner::PlaybackEnded()
 void
 GeckoMediaDecoderOwner::SeekStarted()
 {
+  if (mCallback.mContext && mCallback.mSeekStarted) {
+    (*mCallback.mSeekStarted)(mCallback.mContext);
+  }
 }
 
 void
 GeckoMediaDecoderOwner::SeekCompleted()
 {
+  if (mCallback.mContext && mCallback.mSeekCompleted) {
+    (*mCallback.mSeekCompleted)(mCallback.mContext);
+  }
 }
 
 void

--- a/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -1,0 +1,211 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "GeckoMediaDecoderOwner.h"
+#include "mozilla/AbstractThread.h"
+
+namespace mozilla {
+
+GeckoMediaDecoderOwner::GeckoMediaDecoderOwner(PlayerCallbackObject aCallback)
+  : mCallback(aCallback)
+{
+}
+
+GeckoMediaDecoderOwner::~GeckoMediaDecoderOwner()
+{
+  if (mCallback.mContext && mCallback.mFree) {
+    (*mCallback.mFree)(mCallback.mContext);
+  }
+}
+
+void
+GeckoMediaDecoderOwner::DownloadProgressed()
+{
+}
+
+nsresult
+GeckoMediaDecoderOwner::DispatchAsyncEvent(const nsAString& aName)
+{
+  nsAutoCString dst;
+  CopyUTF16toUTF8(aName, dst);
+  if (mCallback.mContext && mCallback.mAsyncEvent) {
+    (*mCallback.mAsyncEvent)(mCallback.mContext, (const int8_t*)dst.get());
+  }
+  return NS_OK;
+};
+
+void
+GeckoMediaDecoderOwner::UpdateReadyState()
+{
+}
+
+void
+GeckoMediaDecoderOwner::FireTimeUpdate(bool aPeriodic)
+{
+}
+
+bool
+GeckoMediaDecoderOwner::GetPaused()
+{
+  return false;
+}
+
+void
+GeckoMediaDecoderOwner::MetadataLoaded(const MediaInfo* aInfo,
+                                       UniquePtr<const MetadataTags> aTags)
+{
+  // FIXME: serialize aInfo and aTags somehow to callback.
+  if (mCallback.mContext && mCallback.mMetadataLoaded) {
+    (*mCallback.mMetadataLoaded)(mCallback.mContext);
+  }
+}
+
+void
+GeckoMediaDecoderOwner::FirstFrameLoaded()
+{
+}
+
+void
+GeckoMediaDecoderOwner::NetworkError()
+{
+}
+
+void
+GeckoMediaDecoderOwner::DecodeError(const MediaResult& aError)
+{
+  mHasError = true;
+  if (mCallback.mContext && mCallback.mDecodeError) {
+    (*mCallback.mDecodeError)(mCallback.mContext);
+  }
+}
+
+void
+GeckoMediaDecoderOwner::DecodeWarning(const MediaResult& aError)
+{
+}
+
+bool
+GeckoMediaDecoderOwner::HasError() const
+{
+  return mHasError;
+}
+
+void
+GeckoMediaDecoderOwner::LoadAborted()
+{
+}
+
+void
+GeckoMediaDecoderOwner::PlaybackEnded()
+{
+  if (mCallback.mContext && mCallback.mPlaybackEnded) {
+    (*mCallback.mPlaybackEnded)(mCallback.mContext);
+  }
+}
+
+void
+GeckoMediaDecoderOwner::SeekStarted()
+{
+}
+
+void
+GeckoMediaDecoderOwner::SeekCompleted()
+{
+}
+
+void
+GeckoMediaDecoderOwner::DownloadSuspended()
+{
+}
+
+void
+GeckoMediaDecoderOwner::NotifySuspendedByCache(bool aSuspendedByCache)
+{
+}
+
+void
+GeckoMediaDecoderOwner::NotifyDecoderPrincipalChanged()
+{
+}
+
+bool
+GeckoMediaDecoderOwner::IsActive() const
+{
+  return true;
+}
+
+bool
+GeckoMediaDecoderOwner::IsHidden() const
+{
+  return false;
+}
+
+void
+GeckoMediaDecoderOwner::SetAudibleState(bool aAudible)
+{
+}
+
+void
+GeckoMediaDecoderOwner::NotifyXPCOMShutdown()
+{
+}
+
+void
+GeckoMediaDecoderOwner::DispatchEncrypted(const nsTArray<uint8_t>& aInitData,
+                                          const nsAString& aInitDataType)
+{
+}
+
+void
+GeckoMediaDecoderOwner::ConstructMediaTracks(const MediaInfo* aInfo)
+{
+}
+
+void
+GeckoMediaDecoderOwner::RemoveMediaTracks()
+{
+}
+
+void
+GeckoMediaDecoderOwner::AsyncResolveSeekDOMPromiseIfExists()
+{
+}
+
+void
+GeckoMediaDecoderOwner::AsyncRejectSeekDOMPromiseIfExists()
+{
+}
+
+void
+GeckoMediaDecoderOwner::NotifyWaitingForKey()
+{
+}
+
+AbstractThread*
+GeckoMediaDecoderOwner::AbstractMainThread() const
+{
+  return AbstractThread::MainThread();
+}
+
+dom::HTMLMediaElement*
+GeckoMediaDecoderOwner::GetMediaElement()
+{
+  return nullptr;
+}
+
+VideoFrameContainer*
+GeckoMediaDecoderOwner::GetVideoFrameContainer()
+{
+  return nullptr;
+}
+
+already_AddRefed<GMPCrashHelper>
+GeckoMediaDecoderOwner::CreateGMPCrashHelper()
+{
+  return nullptr;
+}
+
+} // namespace mozilla

--- a/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -50,7 +50,7 @@ GeckoMediaDecoderOwner::FireTimeUpdate(bool aPeriodic)
 bool
 GeckoMediaDecoderOwner::GetPaused()
 {
-  return false;
+  return mDecoder && mDecoder->IsOwnerPaused();
 }
 
 void
@@ -206,6 +206,12 @@ already_AddRefed<GMPCrashHelper>
 GeckoMediaDecoderOwner::CreateGMPCrashHelper()
 {
   return nullptr;
+}
+
+void
+GeckoMediaDecoderOwner::SetDecoder(GeckoMediaDecoder* aDecoder)
+{
+  mDecoder = aDecoder;
 }
 
 } // namespace mozilla

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -77,12 +77,10 @@ struct PlayerCallbackObject
 };
 
 void
-GeckoMedia_Player_Create(size_t aId, PlayerCallbackObject aCallback);
-
-void
-GeckoMedia_Player_LoadBlob(size_t aId,
-                           RustVecU8Object aMediaData,
-                           const char* aMimeType);
+GeckoMedia_Player_CreateBlobPlayer(size_t aId,
+                                   RustVecU8Object aMediaData,
+                                   const char* aMimeType,
+                                   PlayerCallbackObject aCallback);
 
 void
 GeckoMedia_Player_Play(size_t aId);

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -57,13 +57,18 @@ struct RustVecU8Object
   void (*mFree)(uint8_t* mData, size_t aLength);
 };
 
+struct GeckoMediaMetadata {
+  double mDuration;
+};
+
 struct PlayerCallbackObject
 {
   void* mContext;
   void (*mPlaybackEnded)(void*);
   void (*mDecodeError)(void*);
   void (*mAsyncEvent)(void*, const int8_t*);
-  void (*mMetadataLoaded)(void*);
+  void (*mMetadataLoaded)(void*, GeckoMediaMetadata);
+  void (*mDurationChanged)(void*, double);
   void (*mLoadedData)(void*);
   void (*mSeekStarted)(void*);
   void (*mSeekCompleted)(void*);
@@ -90,8 +95,5 @@ GeckoMedia_Player_Shutdown(size_t aId);
 
 void
 GeckoMedia_Player_SetVolume(size_t aId, double volume);
-
-double
-GeckoMedia_Player_GetDuration(size_t aId);
 
 #endif // GeckoMedia_h_

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -64,6 +64,10 @@ struct PlayerCallbackObject
   void (*mDecodeError)(void*);
   void (*mAsyncEvent)(void*, const int8_t*);
   void (*mMetadataLoaded)(void*);
+  void (*mLoadedData)(void*);
+  void (*mSeekStarted)(void*);
+  void (*mSeekCompleted)(void*);
+  void (*mTimeUpdate)(void*, double);
   void (*mFree)(void*);
 };
 

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -91,6 +91,9 @@ void
 GeckoMedia_Player_Pause(size_t aId);
 
 void
+GeckoMedia_Player_Seek(size_t aId, double aTimeOffsetSeconds);
+
+void
 GeckoMedia_Player_Shutdown(size_t aId);
 
 void

--- a/gecko/glue/include/GeckoMediaDecoder.h
+++ b/gecko/glue/include/GeckoMediaDecoder.h
@@ -33,6 +33,12 @@ public:
 
   virtual double GetDuration() override;
 
+  void Pause() override;
+
+  nsresult Play() override;
+
+  bool IsOwnerPaused() const;
+
 protected:
   RefPtr<BufferMediaResource> mResource;
 
@@ -45,6 +51,7 @@ private:
   bool IsLiveStream() override final { return !mEnded; }
 
   bool mEnded;
+  bool mOwnerPaused = false;
 };
 
 } // namespace mozilla

--- a/gecko/glue/include/GeckoMediaDecoder.h
+++ b/gecko/glue/include/GeckoMediaDecoder.h
@@ -50,7 +50,7 @@ private:
   bool CanPlayThroughImpl() override;
   bool IsLiveStream() override final { return !mEnded; }
 
-  bool mEnded;
+  bool mEnded = false;
   bool mOwnerPaused = false;
 };
 

--- a/gecko/glue/include/GeckoMediaDecoderOwner.h
+++ b/gecko/glue/include/GeckoMediaDecoderOwner.h
@@ -7,6 +7,7 @@
 #define GeckoMediaDecoderOwner_h_
 
 #include "GeckoMedia.h"
+#include "GeckoMediaDecoder.h"
 #include "MediaDecoderOwner.h"
 #include "MediaInfo.h"
 #include "mozilla/UniquePtr.h"
@@ -187,13 +188,12 @@ public:
   // Called by the media decoder to create a GMPCrashHelper.
   already_AddRefed<GMPCrashHelper> CreateGMPCrashHelper() override;
 
-  /*
-   * Servo only methods go here. Please provide default implementations so they
-   * can build in Gecko without any modification.
-   */
+  void SetDecoder(GeckoMediaDecoder* aDecoder);
+
 private:
   bool mHasError = false;
   PlayerCallbackObject mCallback = { 0 };
+  RefPtr<GeckoMediaDecoder> mDecoder;
 };
 
 } // namespace mozilla

--- a/gecko/glue/include/GeckoMediaDecoderOwner.h
+++ b/gecko/glue/include/GeckoMediaDecoderOwner.h
@@ -29,35 +29,17 @@ class GeckoMediaDecoderOwner : public MediaDecoderOwner
 {
 public:
   GeckoMediaDecoderOwner() {}
-
-  GeckoMediaDecoderOwner(PlayerCallbackObject aCallback)
-    : mCallback(aCallback)
-  {
-  }
-
-  ~GeckoMediaDecoderOwner()
-  {
-    if (mCallback.mContext && mCallback.mFree) {
-      (*mCallback.mFree)(mCallback.mContext);
-    }
-  }
+  GeckoMediaDecoderOwner(PlayerCallbackObject aCallback);
+  ~GeckoMediaDecoderOwner();
 
   // Called by the media decoder to indicate that the download is progressing.
-  virtual void DownloadProgressed() override {}
+  void DownloadProgressed() override;
 
   // Dispatch an asynchronous event to the decoder owner
-  virtual nsresult DispatchAsyncEvent(const nsAString& aName) override
-  {
-    nsAutoCString dst;
-    CopyUTF16toUTF8(aName, dst);
-    if (mCallback.mContext && mCallback.mAsyncEvent) {
-      (*mCallback.mAsyncEvent)(mCallback.mContext, (const int8_t*) dst.get());
-    }
-    return NS_OK;
-  };
+  nsresult DispatchAsyncEvent(const nsAString& aName) override;
 
   // Triggers a recomputation of readyState.
-  virtual void UpdateReadyState() override {}
+  void UpdateReadyState() override;
 
   /**
    * Fires a timeupdate event. If aPeriodic is true, the event will only
@@ -65,87 +47,70 @@ public:
    * last 250ms, as required by the spec when the current time is periodically
    * increasing during playback.
    */
-  virtual void FireTimeUpdate(bool aPeriodic) override {}
+  void FireTimeUpdate(bool aPeriodic) override;
 
   // Return true if decoding should be paused
-  virtual bool GetPaused() override { return false; }
+  bool GetPaused() override;
 
   // Called by the video decoder object, on the main thread,
   // when it has read the metadata containing video dimensions,
   // etc.
   // Must take ownership of MetadataTags aTags argument.
-  virtual void MetadataLoaded(const MediaInfo* aInfo,
-                              UniquePtr<const MetadataTags> aTags) override
-  {
-    // FIXME: serialize aInfo and aTags somehow to callback.
-    if (mCallback.mContext && mCallback.mMetadataLoaded) {
-      (*mCallback.mMetadataLoaded)(mCallback.mContext);
-    }
-  }
+  void MetadataLoaded(const MediaInfo* aInfo,
+                      UniquePtr<const MetadataTags> aTags) override;
 
   // Called by the decoder object, on the main thread,
   // when it has read the first frame of the video or audio.
-  virtual void FirstFrameLoaded() override {}
+  void FirstFrameLoaded() override;
 
   // Called by the decoder object, on the main thread,
   // when the resource has a network error during loading.
   // The decoder owner should call Shutdown() on the decoder and drop the
   // reference to the decoder to prevent further calls into the decoder.
-  virtual void NetworkError() override {}
+  void NetworkError() override;
 
   // Called by the decoder object, on the main thread, when the
   // resource has a decode error during metadata loading or decoding.
   // The decoder owner should call Shutdown() on the decoder and drop the
   // reference to the decoder to prevent further calls into the decoder.
-  virtual void DecodeError(const MediaResult& aError) override
-  {
-    mHasError = true;
-    if (mCallback.mContext && mCallback.mDecodeError) {
-      (*mCallback.mDecodeError)(mCallback.mContext);
-    }
-  }
+  void DecodeError(const MediaResult& aError) override;
 
   // Called by the decoder object, on the main thread, when the
   // resource has a decode issue during metadata loading or decoding, but can
   // continue decoding.
-  virtual void DecodeWarning(const MediaResult& aError) override {}
+  void DecodeWarning(const MediaResult& aError) override;
 
   // Return true if media element error attribute is not null.
-  virtual bool HasError() const override { return mHasError; }
+  bool HasError() const override;
 
   // Called by the video decoder object, on the main thread, when the
   // resource load has been cancelled.
-  virtual void LoadAborted() override {}
+  void LoadAborted() override;
 
   // Called by the video decoder object, on the main thread,
   // when the video playback has ended.
-  virtual void PlaybackEnded() override
-  {
-    if (mCallback.mContext && mCallback.mPlaybackEnded) {
-      (*mCallback.mPlaybackEnded)(mCallback.mContext);
-    }
-  }
+  void PlaybackEnded() override;
 
   // Called by the video decoder object, on the main thread,
   // when the resource has started seeking.
-  virtual void SeekStarted() override {}
+  void SeekStarted() override;
 
   // Called by the video decoder object, on the main thread,
   // when the resource has completed seeking.
-  virtual void SeekCompleted() override {}
+  void SeekCompleted() override;
 
   // Called by the media stream, on the main thread, when the download
   // has been suspended by the cache or because the element itself
   // asked the decoder to suspend the download.
-  virtual void DownloadSuspended() override {}
+  void DownloadSuspended() override;
 
   // Called by the media decoder to indicate whether the media cache has
   // suspended the channel.
-  virtual void NotifySuspendedByCache(bool aSuspendedByCache) override {}
+  void NotifySuspendedByCache(bool aSuspendedByCache) override;
 
   // called to notify that the principal of the decoder's media resource has
   // changed.
-  virtual void NotifyDecoderPrincipalChanged() override {}
+  void NotifyDecoderPrincipalChanged() override;
 
   // The status of the next frame which might be available from the decoder
   enum NextFrameStatus
@@ -164,71 +129,63 @@ public:
   };
 
   // Check if the decoder owner is active.
-  virtual bool IsActive() const override { return true; }
+  bool IsActive() const override;
 
   // Check if the decoder owner is hidden.
-  virtual bool IsHidden() const override { return false; }
+  bool IsHidden() const override;
 
   // Called by media decoder when the audible state changed
-  virtual void SetAudibleState(bool aAudible) override {}
+  void SetAudibleState(bool aAudible) override;
 
   // Notified by the decoder that XPCOM shutdown has begun.
   // The decoder owner should call Shutdown() on the decoder and drop the
   // reference to the decoder to prevent further calls into the decoder.
-  virtual void NotifyXPCOMShutdown() override {}
+  void NotifyXPCOMShutdown() override;
 
   // Dispatches a "encrypted" event to the HTMLMediaElement, with the
   // provided init data. Actual dispatch may be delayed until HAVE_METADATA.
   // Main thread only.
-  virtual void DispatchEncrypted(const nsTArray<uint8_t>& aInitData,
-                                 const nsAString& aInitDataType) override
-  {
-  }
+  void DispatchEncrypted(const nsTArray<uint8_t>& aInitData,
+                         const nsAString& aInitDataType) override;
 
   // Called by the media decoder to create audio/video tracks and add to its
   // owner's track list.
-  virtual void ConstructMediaTracks(const MediaInfo* aInfo) override {}
+  void ConstructMediaTracks(const MediaInfo* aInfo) override;
 
   // Called by the media decoder to removes all audio/video tracks from its
   // owner's track list.
-  virtual void RemoveMediaTracks() override {}
+  void RemoveMediaTracks() override;
 
   // Called by the media decoder to notify the owner to resolve a seek promise.
-  virtual void AsyncResolveSeekDOMPromiseIfExists() override {}
+  void AsyncResolveSeekDOMPromiseIfExists() override;
 
   // Called by the media decoder to notify the owner to reject a seek promise.
-  virtual void AsyncRejectSeekDOMPromiseIfExists() override {}
+  void AsyncRejectSeekDOMPromiseIfExists() override;
 
   // Notified by the decoder that a decryption key is required before emitting
   // further output.
-  virtual void NotifyWaitingForKey() {}
+  void NotifyWaitingForKey() override;
 
   /*
    * Methods that are used only in Gecko go here. We provide defaul
    * implementations so they can compile in Servo without modification.
    */
   // Return an abstract thread on which to run main thread runnables.
-  virtual AbstractThread* AbstractMainThread() const
-  {
-    return AbstractThread::MainThread();
-  }
+  AbstractThread* AbstractMainThread() const override;
 
   // Get the HTMLMediaElement object if the decoder is being used from an
   // HTML media element, and null otherwise.
-  virtual dom::HTMLMediaElement* GetMediaElement() { return nullptr; }
+  dom::HTMLMediaElement* GetMediaElement() override;
 
   // Called by the media decoder and the video frame to get the
   // ImageContainer containing the video data.
-  virtual VideoFrameContainer* GetVideoFrameContainer() { return nullptr; }
+  VideoFrameContainer* GetVideoFrameContainer() override;
 
   // Return the decoder owner's owner document.
-  // virtual nsIDocument* GetDocument() const { return nullptr; }
+  // nsIDocument* GetDocument() const { return nullptr; }
 
   // Called by the media decoder to create a GMPCrashHelper.
-  virtual already_AddRefed<GMPCrashHelper> CreateGMPCrashHelper()
-  {
-    return nullptr;
-  }
+  already_AddRefed<GMPCrashHelper> CreateGMPCrashHelper() override;
 
   /*
    * Servo only methods go here. Please provide default implementations so they

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -41,14 +41,22 @@ fn main() {
             fn playback_ended(&self) {
                 self.sender.send(Status::Ended).unwrap();
             }
-            fn async_event(&self, name: &str) {
-                self.sender.send(Status::AsyncEvent(CString::new(name).unwrap())).unwrap();
-            }
             fn decode_error(&self) {
                 self.sender.send(Status::Error).unwrap();
             }
+            fn async_event(&self, name: &str) {
+                self.sender.send(Status::AsyncEvent(CString::new(name).unwrap())).unwrap();
+            }
             fn metadata_loaded(&self) {
                 self.sender.send(Status::MetadataLoaded).unwrap();
+            }
+            fn loaded_data(&self) {
+            }
+            fn time_update(&self, _time: f64) {
+            }
+            fn seek_started(&self) {
+            }
+            fn seek_completed(&self) {
             }
         }
         let sink = Box::new(Sink { sender: sender });

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -72,22 +72,24 @@ fn main() {
             player.load_blob(bytes, mime).unwrap();
             player.play();
             player.set_volume(1.0);
-            let ok = match receiver.recv().unwrap() {
-                Status::Ended => true,
-                Status::Error => false,
-                Status::AsyncEvent(name) => {
-                    println!("Event received: {:?}", name);
-                    // if name. == "durationchange" {
-                    //     println!("Duration: {:?}", player.get_duration());
-                    // }
-                    true
-                },
-                Status::MetadataLoaded => {
-                    println!("duration: {:?}", player.get_duration());
-                    true
-                }
-            };
-            assert!(ok);
+            loop {
+                match receiver.recv().unwrap() {
+                    Status::Ended => {
+                        println!("Ended");
+                        break;
+                    }
+                    Status::Error => {
+                        println!("Error");
+                        break;
+                    }
+                    Status::AsyncEvent(name) => {
+                        println!("Event received: {:?}", name);
+                    },
+                    Status::MetadataLoaded => {
+                        println!("MetadataLoaded; duration: {:?}", player.get_duration());
+                    },
+                };
+            }
         } else {
             panic!("Unknown file type. Currently supported: wav, mp3, m4a, flac and ogg/vorbis files.")
         }

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -102,7 +102,6 @@ fn main() {
                 "Unknown file type. Currently supported: wav, mp3, m4a, flac and ogg/vorbis files."
             )
         }
-        player.shutdown();
     }
 
     GeckoMedia::shutdown().unwrap();

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -65,6 +65,7 @@ fn main() {
             Some("mp3") => "audio/mp3",
             Some("flac") => "audio/flac",
             Some("ogg") => "audio/ogg; codecs=\"vorbis\"",
+            Some("m4a") => "audio/mp4",
             _ => "",
         };
         if mime != "" {
@@ -88,7 +89,7 @@ fn main() {
             };
             assert!(ok);
         } else {
-            panic!("Unknown file type. Currently supported: wav, mp3, flac and ogg/vorbis files.")
+            panic!("Unknown file type. Currently supported: wav, mp3, m4a, flac and ogg/vorbis files.")
         }
         player.shutdown();
     }

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -60,8 +60,6 @@ fn main() {
         }
         let sink = Box::new(Sink { sender: sender });
 
-        let g = GeckoMedia::get().unwrap();
-        let player = g.create_player(sink).unwrap();
         let mut file = File::open(filename).unwrap();
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
@@ -76,7 +74,10 @@ fn main() {
             _ => "",
         };
         if mime != "" {
-            player.load_blob(bytes, mime).unwrap();
+            let player = GeckoMedia::get()
+                .unwrap()
+                .create_blob_player(bytes, mime, sink)
+                .unwrap();
             player.play();
             player.set_volume(1.0);
             loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,12 +97,20 @@ mod tests {
             player.load_blob(bytes, "audio/wav").unwrap();
             player.play();
 
-            let ok = match receiver.recv().unwrap() {
-                Status::Ended => true,
-                Status::Error => false,
-                Status::AsyncEvent(_name) => true,
-                Status::MetadataLoaded => true
-            };
+            let ok;
+            loop {
+                match receiver.recv().unwrap() {
+                    Status::Ended => {
+                        ok = true;
+                        break;
+                    }
+                    Status::Error => {
+                        ok = false;
+                        break;
+                    }
+                    _ => {}
+                };
+            }
             assert!(ok);
             player.shutdown();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use top::GeckoMedia;
 pub use top::Player;
 pub use top::PlayerEventSink;
+pub use top::Metadata;
 
 #[cfg(test)]
 mod tests {
@@ -36,7 +37,7 @@ mod tests {
     use std::fs::File;
     use std::io::prelude::*;
     use std::sync::mpsc;
-    use {CanPlayType, GeckoMedia, PlayerEventSink, Player};
+    use {CanPlayType, GeckoMedia, Metadata, PlayerEventSink, Player};
 
     fn test_can_play_type() {
         let gecko_media = GeckoMedia::get().unwrap();
@@ -61,7 +62,8 @@ mod tests {
         Error,
         Ended,
         AsyncEvent(CString),
-        MetadataLoaded,
+        MetadataLoaded(Metadata),
+        DurationChanged(f64),
         LoadedData,
         TimeUpdate(f64),
         SeekStarted,
@@ -84,8 +86,11 @@ mod tests {
                     .send(Status::AsyncEvent(CString::new(name).unwrap()))
                     .unwrap();
             }
-            fn metadata_loaded(&self) {
-                self.sender.send(Status::MetadataLoaded).unwrap();
+            fn metadata_loaded(&self, metadata: Metadata) {
+                self.sender.send(Status::MetadataLoaded(metadata)).unwrap();
+            }
+            fn duration_changed(&self, duration: f64) {
+                self.sender.send(Status::DurationChanged(duration)).unwrap();
             }
             fn loaded_data(&self) {
                 self.sender.send(Status::LoadedData).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,11 +106,13 @@ mod tests {
             }
         }
         let sink = Box::new(Sink { sender: sender });
-        let player = GeckoMedia::get().unwrap().create_player(sink).unwrap();
         let mut file = File::open(path).unwrap();
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
-        player.load_blob(bytes, mime).unwrap();
+        let player = GeckoMedia::get()
+            .unwrap()
+            .create_blob_player(bytes, mime, sink)
+            .unwrap();
         player.set_volume(0.001);
         (player, receiver)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ mod tests {
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
         player.load_blob(bytes, mime).unwrap();
+        player.set_volume(0.001);
         (player, receiver)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,10 @@ mod tests {
                 Ended,
                 AsyncEvent(CString),
                 MetadataLoaded,
+                LoadedData,
+                TimeUpdate(f64),
+                SeekStarted,
+                SeekComplete,
             }
             let (sender, receiver) = mpsc::channel();
             struct Sink {
@@ -85,6 +89,18 @@ mod tests {
                 }
                 fn metadata_loaded(&self) {
                     self.sender.send(Status::MetadataLoaded).unwrap();
+                }
+                fn loaded_data(&self) {
+                    self.sender.send(Status::LoadedData).unwrap();
+                }
+                fn time_update(&self, time: f64) {
+                    self.sender.send(Status::TimeUpdate(time)).unwrap();
+                }
+                fn seek_started(&self) {
+                    self.sender.send(Status::SeekStarted).unwrap();
+                }
+                fn seek_completed(&self) {
+                    self.sender.send(Status::SeekComplete).unwrap();
                 }
             }
             let sink = Box::new(Sink { sender: sender });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,28 @@ mod tests {
         (player, receiver)
     }
 
+    fn test_basic_playback()
+    {
+        let (player, receiver) = create_test_player("gecko/test/audiotest.wav", "audio/wav");
+        player.play();
+        let ok;
+        loop {
+            match receiver.recv().unwrap() {
+                Status::Ended => {
+                    ok = true;
+                    break;
+                }
+                Status::Error => {
+                    ok = false;
+                    break;
+                }
+                _ => {}
+            };
+        }
+        assert!(ok);
+        player.shutdown();
+    }
+
     #[test]
     fn run_tests() {
         GeckoMedia::get().unwrap();
@@ -119,28 +141,7 @@ mod tests {
             move || sender.send(()).unwrap(),
         );
         receiver.recv().unwrap();
-
-        {
-            let (player, receiver) = create_test_player("gecko/test/audiotest.wav", "audio/wav");
-            player.play();
-            let ok;
-            loop {
-                match receiver.recv().unwrap() {
-                    Status::Ended => {
-                        ok = true;
-                        break;
-                    }
-                    Status::Error => {
-                        ok = false;
-                        break;
-                    }
-                    _ => {}
-                };
-            }
-            assert!(ok);
-            player.shutdown();
-        }
-
+        test_basic_playback();
         GeckoMedia::shutdown().unwrap();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,6 @@ mod tests {
             };
         }
         assert!(ok);
-        player.shutdown();
     }
 
     fn test_seeking() {
@@ -189,7 +188,6 @@ mod tests {
         assert!(reached_seek_complete);
         assert!(reached_ended);
         assert!(!reached_error);
-        player.shutdown();
     }
 
     #[test]

--- a/src/top.rs
+++ b/src/top.rs
@@ -29,6 +29,10 @@ pub trait PlayerEventSink {
     fn decode_error(&self);
     fn async_event(&self, name: &str);
     fn metadata_loaded(&self);
+    fn loaded_data(&self);
+    fn time_update(&self, time: f64);
+    fn seek_started(&self);
+    fn seek_completed(&self);
 }
 
 impl Player {
@@ -175,12 +179,32 @@ impl GeckoMedia {
             let wrapper = &*(ptr as *mut Wrapper);
             wrapper.sink.metadata_loaded();
         }
+        unsafe extern "C" fn loaded_data(ptr: *mut c_void) {
+            let wrapper = &*(ptr as *mut Wrapper);
+            wrapper.sink.loaded_data();
+        }
+        unsafe extern "C" fn seek_started(ptr: *mut c_void) {
+            let wrapper = &*(ptr as *mut Wrapper);
+            wrapper.sink.seek_started();
+        }
+        unsafe extern "C" fn seek_completed(ptr: *mut c_void) {
+            let wrapper = &*(ptr as *mut Wrapper);
+            wrapper.sink.seek_completed();
+        }
+        unsafe extern "C" fn time_update(ptr: *mut c_void, time: f64) {
+            let wrapper = &*(ptr as *mut Wrapper);
+            wrapper.sink.time_update(time);
+        }
         PlayerCallbackObject {
             mContext: Box::into_raw(Box::new(Wrapper { sink: sink })) as *mut c_void,
             mPlaybackEnded: Some(playback_ended),
             mDecodeError: Some(decode_error),
             mAsyncEvent: Some(async_event),
             mMetadataLoaded: Some(metadata_loaded),
+            mLoadedData: Some(loaded_data),
+            mSeekStarted: Some(seek_started),
+            mSeekCompleted: Some(seek_completed),
+            mTimeUpdate: Some(time_update),
             mFree: Some(free),
         }
     }

--- a/src/top.rs
+++ b/src/top.rs
@@ -42,29 +42,34 @@ impl Player {
             Ok(mime_type) => mime_type,
             _ => return Err(()),
         };
+        let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {
-            GeckoMedia_Player_LoadBlob(self.id, media_data, mime_type.as_ptr());
+            GeckoMedia_Player_LoadBlob(player_id, media_data, mime_type.as_ptr());
         });
         Ok(())
     }
     pub fn play(&self) {
+        let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {
-            GeckoMedia_Player_Play(self.id);
+            GeckoMedia_Player_Play(player_id);
         });
     }
     pub fn pause(&self) {
+        let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {
-            GeckoMedia_Player_Pause(self.id);
+            GeckoMedia_Player_Pause(player_id);
         });
     }
     pub fn shutdown(&self) {
+        let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {
-            GeckoMedia_Player_Shutdown(self.id);
+            GeckoMedia_Player_Shutdown(player_id);
         });
     }
     pub fn set_volume(&self, volume: f64) {
+        let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {
-            GeckoMedia_Player_SetVolume(self.id, volume);
+            GeckoMedia_Player_SetVolume(player_id, volume);
         });
     }
     pub fn get_duration(&self) -> f64 {

--- a/src/top.rs
+++ b/src/top.rs
@@ -96,16 +96,19 @@ impl Player {
             GeckoMedia_Player_Seek(player_id, time_offset_seconds);
         });
     }
-    pub fn shutdown(&self) {
-        let player_id = self.id;
-        self.gecko_media.queue_task(move || unsafe {
-            GeckoMedia_Player_Shutdown(player_id);
-        });
-    }
     pub fn set_volume(&self, volume: f64) {
         let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {
             GeckoMedia_Player_SetVolume(player_id, volume);
+        });
+    }
+}
+
+impl Drop for Player {
+    fn drop(&mut self) {
+        let player_id = self.id;
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_Player_Shutdown(player_id);
         });
     }
 }

--- a/src/top.rs
+++ b/src/top.rs
@@ -90,6 +90,12 @@ impl Player {
             GeckoMedia_Player_Pause(player_id);
         });
     }
+    pub fn seek(&self, time_offset_seconds: f64) {
+        let player_id = self.id;
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_Player_Seek(player_id, time_offset_seconds);
+        });
+    }
     pub fn shutdown(&self) {
         let player_id = self.id;
         self.gecko_media.queue_task(move || unsafe {

--- a/src/top.rs
+++ b/src/top.rs
@@ -24,14 +24,33 @@ pub struct Player {
     id: usize,
 }
 
+/// Users of Player pass in an implementation of this trait when creating
+/// Player objects. When events happen in the Player, users will receive
+/// callbacks upon the trait implementation, notifying them of the event.
 pub trait PlayerEventSink {
+    /// Called when playback has reached the end of media. Playback can
+    /// be resumed from the start of media by calling Player::Play, or by
+    /// seeking.
     fn playback_ended(&self);
+    /// Called if playback has encountered a fatal error. The Player can
+    /// no longer function, and should be dropped.
     fn decode_error(&self);
+    /// Called when the HTML simple event corresponding to `name` should
+    /// be fired at the HTMLMediaElement.
     fn async_event(&self, name: &str);
+    /// Called when initial metadata has been loaded.
     fn metadata_loaded(&self);
+    /// Called when the initial video frame and audio sample have been loaded.
     fn loaded_data(&self);
+    /// Called when the current playback positions changes, reporting the
+    /// current playback position in seconds. This is called whenever the
+    /// playback position changes due to significant events (such as seeking)
+    /// or roughly once per frame while play media. The value reported here
+    /// is HTMLMediaElement.currentTime.
     fn time_update(&self, time: f64);
+    /// Called when the Player has started to seek.
     fn seek_started(&self);
+    /// Called when the Player has stopped seeking.
     fn seek_completed(&self);
 }
 


### PR DESCRIPTION
- Adds and connects a few more callbacks, timeupdate, seeking callbacks, loadeddata, and duration change.
- Using what's added here, it should be possible to implement basic play/pause/seek in Servo with HTMLMediaElement.currentTime reporting the playback position as notified by the PlayerEventSink::time_update() callback.
- Refactored tests to also include a seek test.
- Duration is now reported only via callbacks, it can't be queried directly. I was concerned that the previous method of querying duration is dangerous as it requires blocking the calling (script) thread and waiting on a task to run on the Gecko "main" thread, which could take an unknown amount of time to clear its event queue. So we now rely on GeckoMedia telling us the duration when it reaches loadedmetadata and also notifying if the duration changes.
- Adds basic rustdoc comments to pub structs.