### PR TITLE
Require CMake >= 2.8 instead of 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 2.8)
 project (gecko_media)
 
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
Looks like [gecko-media is failing to build inside of Servo](https://github.com/servo/servo/pull/19152) because gecko-media's CMakeLists.txt says we need CMake 3.1. So let's try downgrading to 2.8 and see if that works.
