### PR TITLE
Rename symbols to avoid conflict with SM ones

### DIFF
--- a/gecko/glue/include/undefs.h
+++ b/gecko/glue/include/undefs.h
@@ -11,3 +11,9 @@
 #undef MOZ_AV1
 
 #undef MOZ_WEBRTC
+
+#define TimeStamp GeckoMedia_TimeStamp
+#define HashBytes GeckoMedia_HashBytes
+#define BaseTimeDurationPlatformUtils GeckoMedia_BaseTimeDurationPlatformUtils
+#define Unused GeckoMedia_Unused
+#define detail GeckoMedia_detail


### PR DESCRIPTION
Following Chris' [suggestion](https://github.com/servo/servo/pull/19152#issuecomment-343383833), this should move https://github.com/servo/servo/pull/19152 forward.