### PR TITLE
TimeStamp binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(gecko_core OBJECT
   gecko/glue/nsTraceRefcnt.cpp
   gecko/glue/nsCRTGlue.cpp
   gecko/glue/Preferences.cpp
+  gecko/glue/RustServices.cpp
   gecko/glue/Scheduler.cpp
   gecko/glue/SchedulerGroup.cpp
   gecko/glue/Services.cpp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ libc = "0.2.32"
 mp4parse = "0.8.0"
 mp4parse_capi = "0.8.0"
 encoding_c = "0.8.0"
+time = "0.1.17"
 
 [features]
 default = ["audio-sample-type-f32"]

--- a/gecko/glue/GeckoMedia.cpp
+++ b/gecko/glue/GeckoMedia.cpp
@@ -21,6 +21,7 @@
 #include "nsTArray.h"
 #include "nsThreadManager.h"
 #include "nsThreadUtils.h"
+#include "RustServices.h"
 
 using namespace mozilla;
 
@@ -67,7 +68,8 @@ AddMainThreadObserver(ThreadObserverObject aObject)
 }
 
 bool
-GeckoMedia_Initialize(ThreadObserverObject aObject)
+GeckoMedia_Initialize(ThreadObserverObject aObject,
+                      RustServicesFnTable aServices)
 {
   NS_SetMainThread();
   if (NS_FAILED(nsThreadManager::get().Init())) {
@@ -94,6 +96,8 @@ GeckoMedia_Initialize(ThreadObserverObject aObject)
   if (NS_FAILED(NS_ProcessPendingEvents(nullptr))) {
     return false;
   }
+
+  RustServices::Init(aServices);
 
   return true;
 }

--- a/gecko/glue/ImageContainer.cpp
+++ b/gecko/glue/ImageContainer.cpp
@@ -398,7 +398,8 @@ ImageContainer::NotifyOwnerOfNewImages()
     img->mPicWidth = data->mPicSize.width;
     img->mPicHeight = data->mPicSize.height;
 
-    img->mTimeStamp = 0; // How to make this portable to Rust?
+    uint64_t rustTime = GeckoMedia_Rust_TimeNow();
+    img->mTimeStamp = rustTime + (owningImage.mTimeStamp - TimeStamp::Now()).ToMicroseconds() * 1000.0;
     img->mFrameID = owningImage.mFrameID;
 
     owningImage.mImage->AddRef();

--- a/gecko/glue/ImageContainer.cpp
+++ b/gecko/glue/ImageContainer.cpp
@@ -40,6 +40,7 @@
 
 #include "mozilla/AbstractThread.h"
 #include "GeckoMediaDecoderOwner.h"
+#include "RustServices.h"
 
 namespace mozilla {
 
@@ -398,7 +399,7 @@ ImageContainer::NotifyOwnerOfNewImages()
     img->mPicWidth = data->mPicSize.width;
     img->mPicHeight = data->mPicSize.height;
 
-    uint64_t rustTime = GeckoMedia_Rust_TimeNow();
+    uint64_t rustTime = RustServices::TimeNow();
     img->mTimeStamp = rustTime + (owningImage.mTimeStamp - TimeStamp::Now()).ToMicroseconds() * 1000.0;
     img->mFrameID = owningImage.mFrameID;
 

--- a/gecko/glue/RustServices.cpp
+++ b/gecko/glue/RustServices.cpp
@@ -1,0 +1,19 @@
+#include "RustServices.h"
+#include "mozilla/Assertions.h"
+
+static RustServicesFnTable sRustServices = {0};
+
+/* static */
+void
+RustServices::Init(const RustServicesFnTable& aServices)
+{
+  sRustServices = aServices;
+}
+
+/* static */
+uint64_t
+RustServices::TimeNow()
+{
+  MOZ_ASSERT(sRustServices.mGetTimeNowFn);
+  return (*sRustServices.mGetTimeNowFn)();
+}

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -69,7 +69,7 @@ struct GeckoPlanarYCbCrImage {
   int32_t mPicWidth;
   int32_t mPicHeight;
 
-  int64_t mTimeStamp;
+  uint64_t mTimeStamp;
   uint32_t mFrameID;
 
   void* mContext;
@@ -132,5 +132,7 @@ GeckoMedia_Player_Shutdown(size_t aId);
 void
 GeckoMedia_Player_SetVolume(size_t aId, double volume);
 }
+
+extern "C" uint64_t GeckoMedia_Rust_TimeNow();
 
 #endif // GeckoMedia_h_

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -22,6 +22,12 @@ struct ThreadObserverObject
   const ThreadObserverVtable* mVtable;
 };
 
+typedef uint64_t (*RustGetTimeNowFn_t)();
+
+struct RustServicesFnTable {
+  RustGetTimeNowFn_t mGetTimeNowFn;
+};
+
 enum CanPlayTypeResult
 {
   No = 0,
@@ -94,7 +100,8 @@ struct PlayerCallbackObject
 
 extern "C" {
 bool
-GeckoMedia_Initialize(ThreadObserverObject aObject);
+GeckoMedia_Initialize(ThreadObserverObject aObject,
+                      RustServicesFnTable aRustServices);
 
 void
 GeckoMedia_Shutdown();
@@ -132,7 +139,5 @@ GeckoMedia_Player_Shutdown(size_t aId);
 void
 GeckoMedia_Player_SetVolume(size_t aId, double volume);
 }
-
-extern "C" uint64_t GeckoMedia_Rust_TimeNow();
 
 #endif // GeckoMedia_h_

--- a/gecko/glue/include/RustServices.h
+++ b/gecko/glue/include/RustServices.h
@@ -1,0 +1,18 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef RustServices_h__
+#define RustServices_h__
+
+#include "GeckoMedia.h"
+
+class RustServices {
+public:
+  static void Init(const RustServicesFnTable& a);
+  static uint64_t TimeNow();
+};
+
+#endif

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -62,7 +62,10 @@ fn main() {
             fn update_current_images(&self, images: Vec<PlanarYCbCrImage>) {
                 for img in images.iter() {
                     let _pixels = img.y_plane.data();
-                    println!("frame display at {} (now is {})", img.time_stamp, TimeStamp(time::precise_time_ns()));
+                    let now = TimeStamp(time::precise_time_ns());
+                    if img.time_stamp > now {
+                        println!("frame display at {} (now is {})", img.time_stamp, now);
+                    }
                 }
             }
         }

--- a/src/bin/test-player.rs
+++ b/src/bin/test-player.rs
@@ -4,13 +4,15 @@
 
 extern crate gecko_media;
 
-use gecko_media::{GeckoMedia, Metadata, PlayerEventSink, PlanarYCbCrImage};
+use gecko_media::{GeckoMedia, Metadata, PlayerEventSink, PlanarYCbCrImage, TimeStamp};
 use std::env;
 use std::ffi::CString;
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::Path;
 use std::sync::mpsc;
+
+extern crate time;
 
 fn main() {
     let args: Vec<_> = env::args().collect();
@@ -60,6 +62,7 @@ fn main() {
             fn update_current_images(&self, images: Vec<PlanarYCbCrImage>) {
                 for img in images.iter() {
                     let _pixels = img.y_plane.data();
+                    println!("frame display at {} (now is {})", img.time_stamp, TimeStamp(time::precise_time_ns()));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod bindings {
 pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use player::{Metadata, PlanarYCbCrImage, Plane, Player, PlayerEventSink, Region};
 pub use top::GeckoMedia;
-pub use timestamp::{GeckoMedia_Rust_TimeNow, TimeStamp};
+pub use timestamp::TimeStamp;
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate mp4parse_capi;
 
 pub mod mime_parser_glue;
 pub mod player;
+pub mod timestamp;
 mod top;
 
 pub mod bindings {
@@ -29,6 +30,7 @@ pub mod bindings {
 pub use bindings::CanPlayTypeResult as CanPlayType;
 pub use player::{Metadata, PlanarYCbCrImage, Plane, Player, PlayerEventSink, Region};
 pub use top::GeckoMedia;
+pub use timestamp::{GeckoMedia_Rust_TimeNow, TimeStamp};
 
 #[cfg(test)]
 mod tests {

--- a/src/player.rs
+++ b/src/player.rs
@@ -7,6 +7,7 @@ use bindings::GeckoPlanarYCbCrImage;
 use bindings::{GeckoMedia_FreeImage, GeckoMedia_Player_Pause, GeckoMedia_Player_Play};
 use bindings::{GeckoMedia_Player_Seek, GeckoMedia_Player_SetVolume, GeckoMedia_Player_Shutdown};
 use std::slice;
+use timestamp::TimeStamp;
 
 /// Plays a media resource.
 pub struct Player {
@@ -97,7 +98,7 @@ pub struct PlanarYCbCrImage {
     /// The sub-region of the buffer which contains the image to be rendered.
     pub picture: Region,
     /// The time at which this image should be renderd.
-    pub time_stamp: i64,
+    pub time_stamp: TimeStamp,
     /// A stream-unique identifier.
     pub frame_id: u32,
     pub gecko_image: GeckoPlanarYCbCrImage,

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use std::{cmp, fmt};
+
+extern crate time;
+
+/// This function is used by Gecko's ImageContainer to translate its internal
+/// TimeStamp to a value in nanoseconds that can be used by Servo's compositor
+/// for synchronization.
+#[no_mangle]
+pub extern "C" fn GeckoMedia_Rust_TimeNow() -> u64 {
+    time::precise_time_ns()
+}
+
+/// Holds a timestamp value expressing monotonic time as nanoseconds.
+pub struct TimeStamp(pub u64);
+
+// This impl is inspired from:
+// https://github.com/sdroege/gstreamer-rs/blob/master/gstreamer/src/clock_time.rs
+impl fmt::Display for TimeStamp {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let precision = f.precision().unwrap_or(9);
+        // TODO: Could also check width and pad the hours as needed
+
+        let (h, m, s, ns) = {
+            let mut s = self.0 / 1_000_000_000;
+            let mut m = s / 60;
+            let h = m / 60;
+            s %= 60;
+            m %= 60;
+            let ns = self.0 % 1_000_000_000;
+
+            (h, m, s, ns)
+        };
+
+        if precision == 0 {
+            f.write_fmt(format_args!("{:02}:{:02}:{:02}", h, m, s))
+        } else {
+            let mut divisor = 1;
+            let precision = cmp::max(precision, 9);
+            for _ in 0..(9 - precision) {
+                divisor *= 10;
+            }
+
+            f.write_fmt(format_args!(
+                "{:02}:{:02}:{:02}.{:0width$}",
+                h,
+                m,
+                s,
+                ns / divisor,
+                width = precision
+            ))
+        }
+    }
+}

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -9,7 +9,6 @@ extern crate time;
 /// This function is used by Gecko's ImageContainer to translate its internal
 /// TimeStamp to a value in nanoseconds that can be used by Servo's compositor
 /// for synchronization.
-#[no_mangle]
 pub extern "C" fn GeckoMedia_Rust_TimeNow() -> u64 {
     time::precise_time_ns()
 }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -15,6 +15,7 @@ pub extern "C" fn GeckoMedia_Rust_TimeNow() -> u64 {
 }
 
 /// Holds a timestamp value expressing monotonic time as nanoseconds.
+#[derive(PartialEq, PartialOrd)]
 pub struct TimeStamp(pub u64);
 
 // This impl is inspired from:

--- a/src/top.rs
+++ b/src/top.rs
@@ -3,6 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 use CanPlayType;
+use TimeStamp;
 use bindings::*;
 use player::{Metadata, Plane, PlanarYCbCrImage, Player, PlayerEventSink, Region};
 use std::ffi::CStr;
@@ -315,7 +316,7 @@ fn to_ffi_planar_ycbycr_images(size: usize, elements: *mut GeckoPlanarYCbCrImage
                 width: img.mPicWidth,
                 height: img.mPicHeight,
             },
-            time_stamp: img.mTimeStamp,
+            time_stamp: TimeStamp(img.mTimeStamp),
             frame_id: img.mFrameID,
             gecko_image: img
         }

--- a/src/top.rs
+++ b/src/top.rs
@@ -16,6 +16,7 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::sync::mpsc::{self, Sender};
 use std::thread::Builder;
+use timestamp::GeckoMedia_Rust_TimeNow;
 
 /// Represents the main connection to the media playback system.
 pub struct GeckoMedia {
@@ -208,8 +209,9 @@ lazy_static! {
         let msg_sender_clone = msg_sender.clone();
         Builder::new().name("GeckoMedia".to_owned()).spawn(move || {
             let thread_observer_object = thread_observer_object(msg_sender_clone);
+            let services = RustServicesFnTable { mGetTimeNowFn: Some(GeckoMedia_Rust_TimeNow) };
             assert!(
-                unsafe { GeckoMedia_Initialize(thread_observer_object) },
+                unsafe { GeckoMedia_Initialize(thread_observer_object, services) },
                 "failed to initialize GeckoMedia"
             );
             ok_sender.send(()).unwrap();


### PR DESCRIPTION
Image timestamps are now passed to Rust world as monotonic u64 values expressing
time in nanoseconds.