### PR TITLE
Introduce GeckoMediaSource

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ add_library(gecko_core OBJECT
   gecko/glue/GeckoMedia.cpp
   gecko/glue/GeckoMediaDecoder.cpp
   gecko/glue/GeckoMediaDecoderOwner.cpp
+  gecko/glue/GeckoMediaSource.cpp
   gecko/glue/ImageContainer.cpp
   gecko/glue/InputEventStatistics.cpp
   gecko/glue/nsDebugImpl.cpp
@@ -145,6 +146,7 @@ add_library(gecko_core OBJECT
   gecko/glue/MediaDecoder.cpp
   gecko/glue/MediaDecoderStateMachine.cpp
   gecko/glue/MediaFormatReader.cpp
+  gecko/glue/MediaSource.cpp
   gecko/glue/MediaStreamGraph.cpp
   gecko/glue/PDMFactory.cpp
   gecko/glue/mozalloc_abort.cpp

--- a/gecko/glue/GeckoMediaSource.cpp
+++ b/gecko/glue/GeckoMediaSource.cpp
@@ -1,0 +1,70 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "GeckoMediaSource.h"
+#include "MediaSource.h"
+
+#include "nsTArray.h"
+#include "UniquePtr.h"
+
+using namespace mozilla;
+using mozilla::dom::MediaSource;
+
+struct GeckoMediaSource
+{
+  GeckoMediaSource(size_t aId, GeckoMediaSourceImpl aImpl)
+    : mMediaSource(MakeUnique<MediaSource>(aImpl))
+    , mId(aId)
+  {
+  }
+
+  UniquePtr<MediaSource> mMediaSource;
+  const size_t mId;
+};
+
+static nsTArray<GeckoMediaSource> sMediaSources;
+
+static GeckoMediaSource*
+GetMediaSource(size_t aId)
+{
+  for (GeckoMediaSource& mediaSource : sMediaSources) {
+    if (mediaSource.mId == aId) {
+      return &mediaSource;
+    }
+  }
+  return nullptr;
+}
+
+void
+GeckoMedia_MediaSource_Create(size_t aId,
+                              GeckoMediaSourceImpl aImpl)
+{
+  GeckoMediaSource* mediaSource =
+    sMediaSources.AppendElement(GeckoMediaSource(aId, aImpl));
+  MOZ_ASSERT(GetMediaSource(aId) == mediaSource);
+}
+
+void
+GeckoMedia_MediaSource_Shutdown(size_t aId)
+{
+  GeckoMediaSource* mediaSource = GetMediaSource(aId);
+  if (NS_WARN_IF(!mediaSource)) {
+    return;
+  }
+
+  for (size_t i = 0; i < sMediaSources.Length(); i++) {
+    if (sMediaSources[i].mId == aId) {
+      sMediaSources.RemoveElementAt(i);
+      break;
+    }
+  }
+}
+
+bool
+GeckoMedia_MediaSource_IsTypeSupported(const char* aMimeType)
+{
+  return MediaSource::IsTypeSupported(aMimeType);
+}

--- a/gecko/glue/MediaSource.cpp
+++ b/gecko/glue/MediaSource.cpp
@@ -1,0 +1,134 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "MediaSource.h"
+
+#if MOZ_AV1
+#include "AOMDecoder.h"
+#endif
+#include "DecoderTraits.h"
+#include "MediaContainerType.h"
+#include "MediaMIMETypes.h"
+#include "mozilla/Logging.h"
+#include "mozilla/Preferences.h"
+#include "nsThreadManager.h"
+
+mozilla::LogModule* GetMediaSourceLog()
+{
+  static mozilla::LazyLogModule sLogModule("MediaSource");
+  return sLogModule;
+}
+
+#define MSE_DEBUG(arg, ...) MOZ_LOG(GetMediaSourceLog(), mozilla::LogLevel::Debug, ("MediaSource(%p)::%s: " arg, this, __func__, ##__VA_ARGS__))
+
+namespace mozilla {
+
+// Returns true if we should enable MSE webm regardless of preferences.
+// 1. If MP4/H264 isn't supported:
+//   * Windows XP
+//   * Windows Vista and Server 2008 without the optional "Platform Update Supplement"
+//   * N/KN editions (Europe and Korea) of Windows 7/8/8.1/10 without the
+//     optional "Windows Media Feature Pack"
+// 2. If H264 hardware acceleration is not available.
+// 3. The CPU is considered to be fast enough
+static bool
+IsWebMForced(DecoderDoctorDiagnostics* aDiagnostics)
+{
+  bool mp4supported =
+    DecoderTraits::IsMP4SupportedType(MediaContainerType(MEDIAMIMETYPE("video/mp4")),
+                                      aDiagnostics);
+  /* TODO (gecko-media) This requires importing mozilla/gfx/gfxVars.h and
+   *                    dependencies
+  bool hwsupported = gfx::gfxVars::CanUseHardwareVideoDecoding();
+#ifdef MOZ_WIDGET_ANDROID
+  return !mp4supported || !hwsupported || VP9Benchmark::IsVP9DecodeFast() ||
+         java::HardwareCodecCapabilityUtils::HasHWVP9();
+#else
+  return !mp4supported || !hwsupported || VP9Benchmark::IsVP9DecodeFast();
+#endif
+  */
+  return !mp4supported;
+}
+
+namespace dom {
+
+MediaSource::MediaSource(GeckoMediaSourceImpl aImpl)
+  : mImpl(aImpl)
+{
+}
+
+MediaSource::~MediaSource()
+{
+  if (mImpl.mContext && mImpl.mFree) {
+    (*mImpl.mFree)(mImpl.mContext);
+  }
+}
+
+MediaSourceReadyState
+MediaSource::ReadyState()
+{
+  MOZ_ASSERT(NS_IsMainThread());
+  if (NS_WARN_IF(!mImpl.mContext || !mImpl.mGetReadyState)) {
+      return MediaSourceReadyState::Unknown;
+  }
+
+  return (*mImpl.mGetReadyState)(mImpl.mContext);
+}
+
+/* static */
+bool
+MediaSource::IsTypeSupported(const char* aType)
+{
+  auto containerType = MakeMediaContainerType(aType);
+  if (containerType.isNothing()) {
+    return false;
+  }
+
+  if (DecoderTraits::CanHandleContainerType(containerType.value(), nullptr)
+      == CANPLAY_NO) {
+    return false;
+  }
+
+  // Now we know that this media type could be played.
+  // MediaSource imposes extra restrictions, and some prefs.
+  const MediaMIMEType& mimeType = containerType->Type();
+
+  if (mimeType == MEDIAMIMETYPE("video/mp4") ||
+      mimeType == MEDIAMIMETYPE("audio/mp4")) {
+    if (!Preferences::GetBool("media.mediasource.mp4.enabled", false)) {
+      return false;
+    }
+    return true;
+  }
+
+  if (mimeType == MEDIAMIMETYPE("video/webm")) {
+    if (!(Preferences::GetBool("media.mediasource.webm.enabled", false) ||
+          containerType->ExtendedType().Codecs().Contains(
+            NS_LITERAL_STRING("vp8")) ||
+#ifdef MOZ_AV1
+          // FIXME: Temporary comparison with the full codecs attribute.
+          // See bug 1377015.
+          AOMDecoder::IsSupportedCodec(containerType->ExtendedType().Codecs().AsString()) ||
+#endif
+          IsWebMForced(nullptr))) {
+      return false;
+    }
+    return true;
+  }
+
+  if (mimeType == MEDIAMIMETYPE("audio/webm")) {
+    if (!(Preferences::GetBool("media.mediasource.webm.enabled", false) ||
+          Preferences::GetBool("media.mediasource.webm.audio.enabled", true))) {
+      return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace dom
+} // namespace mozilla

--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -7,6 +7,8 @@
 #ifndef GeckoMedia_h_
 #define GeckoMedia_h_
 
+#include "GeckoMediaSource.h"
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/gecko/glue/include/GeckoMediaSource.h
+++ b/gecko/glue/include/GeckoMediaSource.h
@@ -1,0 +1,39 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef GeckoMediaSource_h_
+#define GeckoMediaSource_h_
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct GeckoMediaSource;
+
+enum class MediaSourceReadyState {
+  Closed = 0,
+  Open,
+  Ended,
+  Unknown,
+  EndGuard_
+};
+
+struct GeckoMediaSourceImpl
+{
+  void* mContext;
+  void (*mFree)(void*);
+  MediaSourceReadyState (*mGetReadyState)(void*);
+};
+
+extern "C" {
+  void GeckoMedia_MediaSource_Create(size_t aId,
+                                     GeckoMediaSourceImpl aImpl);
+
+  void GeckoMedia_MediaSource_Shutdown(size_t aId);
+
+  bool GeckoMedia_MediaSource_IsTypeSupported(const char* aMimeType);
+}
+
+#endif // GeckoMediaSource_h

--- a/gecko/glue/include/MediaSource.h
+++ b/gecko/glue/include/MediaSource.h
@@ -1,0 +1,31 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef mozilla_dom_MediaSource_h
+#define mozilla_dom_MediaSource_h
+
+#include "GeckoMediaSource.h"
+
+namespace mozilla {
+namespace dom {
+
+class MediaSource final
+{
+public:
+  MediaSource(GeckoMediaSourceImpl aGeckoMediaSourceImpl);
+  ~MediaSource();
+
+  MediaSourceReadyState ReadyState();
+
+  static bool IsTypeSupported(const char* aType);
+private:
+  GeckoMediaSourceImpl mImpl;
+};
+
+} // namespace dom
+} // namespace mozilla
+
+#endif // mozilla_dom_MediaSource_h

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ extern crate mime;
 extern crate mp4parse_capi;
 
 pub mod mime_parser_glue;
+pub mod mse;
 pub mod player;
 pub mod timestamp;
 mod top;
@@ -26,19 +27,19 @@ pub mod bindings {
 
 #[doc(inline)]
 pub use bindings::CanPlayTypeResult as CanPlayType;
+pub use mse::mediasource::{MediaSource as GeckoMediaSource, MediaSourceImpl as GeckoMediaSourceImpl};
 pub use player::{Metadata, PlanarYCbCrImage, Plane, Player, PlayerEventSink, Region};
 pub use top::GeckoMedia;
 pub use timestamp::TimeStamp;
 
 #[cfg(test)]
 mod tests {
-    use CanPlayType;
-    use GeckoMedia;
     use player::{Metadata, PlanarYCbCrImage, Player, PlayerEventSink};
     use std::ffi::CString;
     use std::fs::File;
     use std::io::prelude::*;
     use std::sync::mpsc;
+    use {CanPlayType, GeckoMedia, GeckoMediaSource, GeckoMediaSourceImpl};
 
     fn test_can_play_type() {
         let gecko_media = GeckoMedia::get().unwrap();
@@ -200,6 +201,91 @@ mod tests {
         assert!(!reached_error);
     }
 
+    fn test_media_source() {
+        use std::cell::{Cell, RefCell};
+        use std::rc::{Rc, Weak};
+
+        let gecko_media = GeckoMedia::get().unwrap();
+        #[derive(Clone, Copy)]
+        #[allow(dead_code)]
+        enum MediaSourceReadyState {
+            Closed,
+            Open,
+            Ended,
+            Unknown,
+        }
+        struct MediaSourceDummyDomObject {
+            pub ready_state: Cell<MediaSourceReadyState>,
+            gecko_media_source: RefCell<Option<Weak<GeckoMediaSource>>>,
+        }
+        impl MediaSourceDummyDomObject {
+            pub fn new() -> Self {
+                MediaSourceDummyDomObject {
+                    ready_state: Cell::new(MediaSourceReadyState::Closed),
+                    gecko_media_source: RefCell::new(None),
+                }
+            }
+
+            pub fn set_gecko_media_source(&self,
+                                          gecko_media_source: Weak<GeckoMediaSource>) {
+                *self.gecko_media_source.borrow_mut() = Some(gecko_media_source);
+            }
+
+            pub fn is_type_supported(&self, mime_type: &str) -> bool {
+                if let Some(ref gecko_media_source) = *self.gecko_media_source.borrow() {
+                    if let Some(gecko_media_source) = gecko_media_source.upgrade() {
+                        gecko_media_source.is_type_supported(mime_type)
+                    } else {
+                        panic!("GeckoMediaSource gone");
+                    }
+                } else {
+                    panic!("GeckoMediaSource not set");
+                }
+            }
+
+        }
+        struct MediaSourceImpl {
+            dom_object: Rc<MediaSourceDummyDomObject>,
+        }
+        impl MediaSourceImpl {
+            pub fn new(dom_object: Rc<MediaSourceDummyDomObject>) -> Self {
+                MediaSourceImpl {
+                    dom_object,
+                }
+            }
+        }
+        impl GeckoMediaSourceImpl for MediaSourceImpl {
+            fn get_ready_state(&self) -> i32 {
+                match self.dom_object.ready_state.get() {
+                    MediaSourceReadyState::Closed => 0,
+                    MediaSourceReadyState::Open => 1,
+                    MediaSourceReadyState::Ended => 2,
+                    MediaSourceReadyState::Unknown => 3,
+                }
+            }
+        }
+        let media_source_dom = Rc::new(MediaSourceDummyDomObject::new());
+        let media_source_impl = Box::new(MediaSourceImpl::new(media_source_dom.clone()));
+        let gecko_media_source = Rc::new(gecko_media.create_media_source(media_source_impl).unwrap());
+        media_source_dom.set_gecko_media_source(Rc::downgrade(&gecko_media_source));
+        assert_eq!(media_source_dom.is_type_supported("bogus/bogus"), false);
+        assert_eq!(
+            media_source_dom.is_type_supported("audio/mp4; codecs=\"bogus\""),
+            false
+        );
+        assert_eq!(media_source_dom.is_type_supported("video/mp4"), true);
+        assert_eq!(media_source_dom.is_type_supported("audio/mp4"), true);
+        assert_eq!(media_source_dom.is_type_supported("audio/webm"), false);
+        assert_eq!(media_source_dom.is_type_supported("audio/mp3"), false);
+        assert_eq!(media_source_dom.is_type_supported("audio/flac"), false);
+        assert_eq!(media_source_dom.is_type_supported("audio/ogg"), false);
+        assert_eq!(
+            media_source_dom.is_type_supported("audio/ogg; codecs=\"vorbis\""),
+            false
+        );
+        assert_eq!(media_source_dom.is_type_supported("audio/wav"), false);
+    }
+
     #[test]
     fn run_tests() {
         GeckoMedia::get().unwrap();
@@ -212,6 +298,7 @@ mod tests {
         receiver.recv().unwrap();
         test_basic_playback();
         test_seeking();
+        test_media_source();
         GeckoMedia::shutdown().unwrap();
     }
 }

--- a/src/mse/mediasource.rs
+++ b/src/mse/mediasource.rs
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use GeckoMedia;
+use bindings::{GeckoMedia_MediaSource_Create, GeckoMedia_MediaSource_IsTypeSupported};
+use bindings::{GeckoMedia_MediaSource_Shutdown, GeckoMediaSourceImpl};
+use std::ffi::CString;
+use std::os::raw::c_void;
+use std::sync::mpsc;
+
+pub struct MediaSource {
+    gecko_media: GeckoMedia,
+    id: usize,
+}
+
+impl MediaSource {
+    pub fn new(gecko_media: GeckoMedia,
+               id: usize,
+               media_source_impl: Box<MediaSourceImpl>) -> MediaSource {
+        let callbacks = to_ffi_callbacks(media_source_impl);
+        gecko_media.queue_task(move || unsafe {
+            GeckoMedia_MediaSource_Create(id, callbacks);
+        });
+        MediaSource {
+            gecko_media,
+            id,
+        }
+    }
+
+    pub fn is_type_supported(&self, mime_type: &str) -> bool {
+        if let Ok(mime_type) = CString::new(mime_type.as_bytes()) {
+            let (sender, receiver) = mpsc::channel();
+            self.gecko_media.queue_task(move || unsafe {
+                sender.send(GeckoMedia_MediaSource_IsTypeSupported(mime_type.as_ptr())).unwrap();
+            });
+            receiver.recv().unwrap()
+        } else {
+            false
+        }
+    }
+}
+
+impl Drop for MediaSource {
+    fn drop(&mut self) {
+        let mediasource_id = self.id;
+        self.gecko_media.queue_task(move || unsafe {
+            GeckoMedia_MediaSource_Shutdown(mediasource_id);
+        });
+    }
+}
+
+/// Users of MediaSource pass in an implementation of this trait when creating
+/// MediaSource objects.
+pub trait MediaSourceImpl {
+    /// MediaSource ready state getter.
+    fn get_ready_state(&self) -> i32;
+}
+
+fn to_ffi_callbacks(media_source_impl: Box<MediaSourceImpl>) -> GeckoMediaSourceImpl {
+    // Can't cast from *c_void to a Trait, so wrap in a concrete type
+    // when we pass into C++ code.
+    struct Wrapper {
+        media_source_impl: Box<MediaSourceImpl>,
+    }
+    unsafe extern "C" fn free(ptr: *mut c_void) {
+        drop(Box::from_raw(ptr as *mut Wrapper));
+    }
+    unsafe extern "C" fn get_ready_state(ptr: *mut c_void) -> i32 {
+        let wrapper = &*(ptr as *mut Wrapper);
+        wrapper.media_source_impl.get_ready_state()
+    }
+
+    GeckoMediaSourceImpl {
+        mContext: Box::into_raw(Box::new(Wrapper { media_source_impl })) as *mut c_void,
+        mFree: Some(free),
+        mGetReadyState: Some(get_ready_state),
+    }
+}

--- a/src/mse/mod.rs
+++ b/src/mse/mod.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! The implementation of the Media Source Extensions API.
+
+pub mod mediasource;

--- a/src/player.rs
+++ b/src/player.rs
@@ -168,7 +168,7 @@ impl Player {
     pub fn new(gecko_media: GeckoMedia, id: usize) -> Player {
         Player {
             gecko_media,
-            id
+            id,
         }
     }
 

--- a/src/top.rs
+++ b/src/top.rs
@@ -5,6 +5,7 @@
 use CanPlayType;
 use TimeStamp;
 use bindings::*;
+use mse::mediasource::{MediaSource, MediaSourceImpl};
 use player::{Metadata, Plane, PlanarYCbCrImage, Player, PlayerEventSink, Region};
 use std::ffi::CStr;
 use std::ffi::CString;
@@ -205,6 +206,13 @@ impl GeckoMedia {
         }
     }
 
+    pub fn create_media_source(&self, media_source_impl: Box<MediaSourceImpl>)
+        -> Result<MediaSource, ()> {
+        let handle = GeckoMedia::get()?;
+        let id = NEXT_MEDIA_SOURCE_ID.fetch_add(1, Ordering::SeqCst);
+        Ok(MediaSource::new(handle, id, media_source_impl))
+    }
+
     #[cfg(test)]
     pub fn test(&self) {
         self.sender.send(GeckoMediaMsg::Test).unwrap();
@@ -227,6 +235,7 @@ enum GeckoMediaMsg {
 
 static OUTSTANDING_HANDLES: AtomicUsize = ATOMIC_USIZE_INIT;
 static NEXT_PLAYER_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static NEXT_MEDIA_SOURCE_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 static mut SENDER: *const Mutex<Option<Sender<GeckoMediaMsg>>> = 0 as *const _;
 static INITIALIZER: Once = sync::ONCE_INIT;
 


### PR DESCRIPTION
For now, it's only implementing the [MediaSource.IsSupportedType()](https://www.w3.org/TR/media-source/#dom-mediasource-istypesupported) method.