### PR TITLE
Include GeckoMediaSource in wrapper.hpp

### DIFF
--- a/gecko/glue/include/GeckoMedia.h
+++ b/gecko/glue/include/GeckoMedia.h
@@ -7,8 +7,6 @@
 #ifndef GeckoMedia_h_
 #define GeckoMedia_h_
 
-#include "GeckoMediaSource.h"
-
 #include <stddef.h>
 #include <stdint.h>
 

--- a/gecko/glue/include/wrapper.hpp
+++ b/gecko/glue/include/wrapper.hpp
@@ -1,1 +1,2 @@
 #include "GeckoMedia.h"
+#include "GeckoMediaSource.h"


### PR DESCRIPTION
The only reason it was included in `GeckoMedia.h` was to let bindgen do its work. But I guess `wrapper.hpp` is the correct location for that.