### PR TITLE
Depend on cubeb-ffi and pulse-ffi directly

### DIFF
--- a/gecko-media/Cargo.toml
+++ b/gecko-media/Cargo.toml
@@ -9,7 +9,8 @@ doctest = false
 name = "gecko_media"
 
 [target.'cfg(unix)'.dependencies]
-cubeb-pulse = { git = "https://github.com/djg/cubeb-pulse-rs", branch = "dev", features = ["pulse-dlopen"]}
+cubeb-ffi = {git = "https://github.com/djg/cubeb-pulse-rs", branch = "dev"}
+pulse-ffi = {git = "https://github.com/djg/cubeb-pulse-rs", branch = "dev", features = ["dlopen"]}
 
 [build-dependencies]
 bindgen = "0.31.0"

--- a/gecko-media/src/lib.rs
+++ b/gecko-media/src/lib.rs
@@ -7,13 +7,15 @@
 #![allow(non_snake_case)]
 
 #[allow(unused_extern_crates)]
-extern crate cubeb_pulse;
+extern crate cubeb_ffi;
 #[allow(unused_extern_crates)]
 extern crate encoding_c;
 extern crate libc;
 extern crate mime;
 #[allow(unused_extern_crates)]
 extern crate mp4parse_capi;
+#[allow(unused_extern_crates)]
+extern crate pulse_ffi;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
There is no need to build the Rust bindings, given only C++ code makes use of these crates.