### PR TITLE
MacOS playback fixes

### DIFF
--- a/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -71,8 +71,8 @@ GeckoMediaDecoderOwner::MetadataLoaded(const MediaInfo* aInfo,
   if (mCallback.mContext && mCallback.mMetadataLoaded) {
     GeckoMediaMetadata metadata = { 0, 0, 0 };
     if (aInfo->HasVideo()) {
-      metadata.mVideoWidth = aInfo->mVideo.ImageRect().Width();
-      metadata.mVideoHeight = aInfo->mVideo.ImageRect().Height();
+      metadata.mVideoWidth = aInfo->mVideo.mDisplay.width;
+      metadata.mVideoHeight = aInfo->mVideo.mDisplay.height;
     }
     metadata.mDuration = mDecoder->GetDuration();
     (*mCallback.mMetadataLoaded)(mCallback.mContext, metadata);

--- a/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -293,6 +293,14 @@ void
 GeckoMediaDecoderOwner::Shutdown()
 {
   if (mVideoFrameContainer) {
+    // The ImageContainer keeps a list of the images that it sends out to Rust,
+    // so that if we shutdown, we can deallocate and neuter the images
+    // proactively. If we don't do this, we can end up with crashes if Rust
+    // code on another thread tries to use images after we've shutdown.
+    auto imageContainer = mVideoFrameContainer->GetImageContainer();
+    if (imageContainer) {
+      imageContainer->DeallocateExportedImages();
+    }
     mVideoFrameContainer->ForgetElement();
     mVideoFrameContainer = nullptr;
   }

--- a/gecko-media/gecko/glue/include/ImageContainer.h
+++ b/gecko-media/gecko/glue/include/ImageContainer.h
@@ -622,6 +622,9 @@ public:
 
   // void DropImageClient();
 
+  void DeallocateExportedImages();
+  void RecordImageDropped(size_t aFrameID);
+
 private:
   typedef mozilla::RecursiveMutex RecursiveMutex;
 
@@ -694,7 +697,10 @@ private:
 
   static mozilla::Atomic<uint32_t> sGenerationCounter;
 
+  void RecordImageExported(size_t aFrameID);
+
   RefPtr<GeckoMediaDecoderOwner> mOwner;
+  nsTArray<size_t> mExportedImages;
 };
 
 class AutoLockImage


### PR DESCRIPTION
- Fix rendering so that we render frames taking into account the Pixel Aspect Ratio. This means videos render at the correct size, rather than at the size of the video frames.
- Check for window resize on every frame. On MacOS we don't get resize event from glutin, so this change makes us render correctly after a resize.
- We still don't handle painting *during* a resize on MacOS (between mouse-down and mouse-up). That's much more complicated to get working.
- Fix a shutdown crash; if I quit while playing back, I was getting an assert in the threading code while trying to deallocate video frames. The problem was were were dropping the frames from Rust code after the gecko-media Player had been shutdown which confused the threading safety checks. So now each ImageContainer tracks what frames it's exported into Rust code, and when it shuts down it deallocates those frames. The objects still exported to Rust will be neutered, so we won't crash when Rust tries to drop them after GeckoMedia has shutdown.
