### PR TITLE
Example player playback position and buffered UI

### DIFF
--- a/examples/src/mirror.rs
+++ b/examples/src/mirror.rs
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use std::sync::{Arc, RwLock};
+
+/// Provides a way to share a value which is updated on one thread
+/// with a consumer on another thread. The Canonical resides on
+/// the producer thread, and sets the value when it changes.
+/// The Mirror resides on the consumer thread, and the consumer
+/// can retrieve a copy of the latest value when it needs to use it.
+pub struct Mirror<T>
+where
+    T: Clone,
+{
+    value: Arc<RwLock<T>>,
+}
+
+pub struct Canonical<T>
+where
+    T: Clone,
+{
+    value: Arc<RwLock<T>>,
+}
+
+impl<T> Mirror<T>
+where
+    T: Clone,
+{
+    /// Creates a new (Mirror<T>, Canonical<T>) pair. They can be sent
+    /// to different threads, to share a value between threads.
+    pub fn new(default_value: T) -> (Mirror<T>, Canonical<T>) {
+        let value = Arc::new(RwLock::new(default_value));
+        (
+            Mirror {
+                value: value.clone(),
+            },
+            Canonical {
+                value,
+            },
+        )
+    }
+    /// Gets a copy of the latest value stored in the matching Canonical.
+    pub fn get(&self) -> T {
+        let value = self.value.read().expect(
+            "Failed to acquire Mirror read lock",
+        );
+        (*value).clone()
+    }
+}
+
+impl<T> Canonical<T>
+where
+    T: Clone,
+{
+    /// Sets the shared value. Mirror can read this on another thread using
+    /// Mirror::get().
+    pub fn set(&self, value: T) {
+        let mut v = self.value.write().expect(
+            "Failed to acquire Canonical write lock",
+        );
+        *v = value;
+    }
+}

--- a/examples/src/ui.rs
+++ b/examples/src/ui.rs
@@ -85,7 +85,7 @@ pub trait Example {
     fn should_close_window(&mut self) -> bool {
         false
     }
-    fn video_dimensions(&mut self) -> Option<(i32, i32)> {
+    fn video_dimensions(&self) -> Option<(i32, i32)> {
         None
     }
 }
@@ -192,8 +192,10 @@ pub fn main_wrapper(example: &mut Example, options: Option<webrender::RendererOp
             api.set_window_parameters(
                 document_id,
                 DeviceUintSize::new(width, height),
-                DeviceUintRect::new(DeviceUintPoint::new(0, 0),
-                                    DeviceUintSize::new(width, height)),
+                DeviceUintRect::new(
+                    DeviceUintPoint::new(0, 0),
+                    DeviceUintSize::new(width, height),
+                ),
                 window.hidpi_factor(),
             );
         }

--- a/examples/src/ui.rs
+++ b/examples/src/ui.rs
@@ -39,6 +39,28 @@ impl RenderNotifier for Notifier {
     }
 }
 
+pub trait HandyDandyRectBuilder {
+    fn to(&self, x2: i32, y2: i32) -> LayoutRect;
+    fn by(&self, w: i32, h: i32) -> LayoutRect;
+}
+// Allows doing `(x, y).to(x2, y2)` or `(x, y).by(width, height)` with i32
+// values to build a f32 LayoutRect
+impl HandyDandyRectBuilder for (i32, i32) {
+    fn to(&self, x2: i32, y2: i32) -> LayoutRect {
+        LayoutRect::new(
+            LayoutPoint::new(self.0 as f32, self.1 as f32),
+            LayoutSize::new((x2 - self.0) as f32, (y2 - self.1) as f32),
+        )
+    }
+
+    fn by(&self, w: i32, h: i32) -> LayoutRect {
+        LayoutRect::new(
+            LayoutPoint::new(self.0 as f32, self.1 as f32),
+            LayoutSize::new(w as f32, h as f32),
+        )
+    }
+}
+
 pub trait Example {
     fn render(
         &mut self,


### PR DESCRIPTION
- Add Mirror and Canonical to share values between threads.
- Use Mirror/Canonical instead of channels to share duration, time, buffered, and video dimensions between threads in example player. This makes more sense than using channels where we must do a try_recv() in a loop to get the latest value.
- Add UI to render the current playback position, and the buffered ranges.
- We're currently not updating the buffered ranges when data comes in over the network, so it's not very impressive yet. I'll fix that in a later PR. We'll probably need to rework the NetworkResource trait to make that possible.