### PR TITLE
Avoid duplicating symbols between mozjs and gecko-media.

### DIFF
--- a/gecko-media/gecko/glue/include/undefs.h
+++ b/gecko-media/gecko/glue/include/undefs.h
@@ -42,3 +42,7 @@
 #define gMozillaPoisonSize GeckoMedia_gMozillaPoisonSize
 #define gMozillaPoisonBase GeckoMedia_gMozillaPoisonBase
 #define gMozillaPoisonValue GeckoMedia_gMozillaPoisonValue
+
+// Avoid duplicating symbols from the mozilla namespace used by this repository
+// as well as SpiderMonkey.
+#define mozilla GeckoMedia_mozilla


### PR DESCRIPTION
This fixes https://github.com/servo/servo/issues/19348, by avoiding the violations of the [one definition rule](https://en.wikipedia.org/wiki/One_Definition_Rule) caused by linking mozjs's mfbt in with gecko-media's copy.