### PR TITLE
Disable Android cross-build on OSX Travis builders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,26 +75,26 @@ before_install:
       export CC=gcc-5 CXX=g++-5
     fi
   - |
-    # Download Android NDK
-    export ANDROID_HOME="${HOME}/android-ndk"
-    export ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk-${ANDROID_NDK_VERSION}"
-    mkdir -p $ANDROID_HOME
-    if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      PKG_OS="darwin"
-    else
-      PKG_OS="linux"
+    # Download Android NDK for Linux.
+    if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
+      export ANDROID_HOME="${HOME}/android-ndk"
+      export ANDROID_NDK_HOME="${ANDROID_HOME}/android-ndk-${ANDROID_NDK_VERSION}"
+      mkdir -p $ANDROID_HOME
+      curl -o ndk.zip "https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-linux-x86_64.zip"
+      unzip -q ndk.zip -d $ANDROID_HOME
+      rustup target add arm-linux-androideabi
+      ./create-ndk-standalone.sh
+      mkdir -p ./.cargo
+      mv cargo-config.toml ./.cargo/config
     fi;
-    curl -o ndk.zip "https://dl.google.com/android/repository/android-ndk-${ANDROID_NDK_VERSION}-${PKG_OS}-x86_64.zip"
-    unzip -q ndk.zip -d $ANDROID_HOME
-    rustup target add arm-linux-androideabi
-    ./create-ndk-standalone.sh
-    mkdir -p ./.cargo
-    mv cargo-config.toml ./.cargo/config
-
 
 script:
   - env
   - servo-tidy
   - RUST_BACKTRACE=1 cargo test --verbose $CARGO_FLAGS
-  - RUST_BACKTRACE=1 CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ PATH=$PWD/NDK/arm/bin:$PATH cargo build --verbose --target arm-linux-androideabi $CARGO_FLAGS
+  - |
+    # Disable Android cross-build on OSX because macOS Travis builders are too slow.
+    if [ "${TRAVIS_OS_NAME}" != "osx" ]; then
+      RUST_BACKTRACE=1 CC=arm-linux-androideabi-gcc CXX=arm-linux-androideabi-g++ PATH=$PWD/NDK/arm/bin:$PATH cargo build --verbose --target arm-linux-androideabi $CARGO_FLAGS
+    fi;
   - sccache --show-stats


### PR DESCRIPTION
Since the Android build support was added the macOS builders frequently timeout.
Having Android build enabled for the Linux builders should be enough for now.