### PR TITLE
Set explicit revision on examples webrender dependency

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Chris Pearce <cpearce@mozilla.com>", "Philippe Normand <philn@igalia
 
 [dependencies]
 gecko-media = { path = "../gecko-media" }
-webrender = { git = "https://github.com/servo/webrender/" }
+webrender = { git = "https://github.com/servo/webrender/", rev="e558d41b" }
 gleam = "0.4.8"
 servo-glutin = "0.12"
 time = "0.1.17"


### PR DESCRIPTION
Roll back to e558d41b to avoid version conflicts between serde and the patched
version currently needed by webrender git master.

See also https://github.com/servo/servo/issues/19543