### PR TITLE
Ensure video frames are stored in Rust allocated memory

### DIFF
--- a/examples/src/bin/test-player.rs
+++ b/examples/src/bin/test-player.rs
@@ -272,7 +272,7 @@ impl webrender::ExternalImageHandler for ImageGenerator {
             source: webrender::ExternalImageSource::RawData(
                 self.current_image
                     .as_ref()
-                    .map(|p| p.pixel_data(channel_index))
+                    .map(|img| img.plane_for_channel(channel_index).pixels)
                     .unwrap(),
             ),
         }

--- a/examples/src/bin/test-player.rs
+++ b/examples/src/bin/test-player.rs
@@ -272,7 +272,7 @@ impl webrender::ExternalImageHandler for ImageGenerator {
             source: webrender::ExternalImageSource::RawData(
                 self.current_image
                     .as_ref()
-                    .map(|img| img.plane_for_channel(channel_index).pixels)
+                    .map(|img| &img.plane_for_channel(channel_index).pixels)
                     .unwrap(),
             ),
         }
@@ -320,7 +320,7 @@ impl App {
         api: &RenderApi,
         resources: &mut ResourceUpdates,
         image_key: Option<ImageKey>,
-        plane: Plane,
+        plane: &Plane,
         channel_index: u8,
     ) -> Option<ImageKey> {
         match image_key {
@@ -452,13 +452,13 @@ impl ui::Example for App {
         }
 
         let time_now = TimeStamp(time::precise_time_ns());
-        while self.frame_queue.len() > 1 && self.frame_queue[0].time_stamp > time_now {
+        while self.frame_queue.len() > 1 && self.frame_queue[0].timestamp() > time_now {
             self.frame_queue.remove(0);
         }
 
         if let Some(first_frame) = self.frame_queue.first() {
-            if self.last_frame_id != first_frame.frame_id {
-                self.last_frame_id = first_frame.frame_id;
+            if self.last_frame_id != first_frame.frame_id() {
+                self.last_frame_id = first_frame.frame_id();
                 self.current_frame_sender.as_ref().map(|sender| {
                     sender.send(first_frame.clone()).unwrap();
                 });
@@ -513,7 +513,10 @@ impl ui::Example for App {
             // intrinsic size, we'll just use the frame size.
             let (width, height) = match self.video_dimensions() {
                 Some((width, height)) => (width, height),
-                None => (frame.picture.width, frame.picture.height),
+                None => (
+                    frame.picture_region().width as i32,
+                    frame.picture_region().height as i32,
+                ),
             };
 
             // Resize so that the video is rendered as wide as the window.

--- a/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -247,10 +247,12 @@ GeckoMediaDecoderOwner::SetDecoder(GeckoMediaDecoder* aDecoder)
 }
 
 void
-GeckoMediaDecoderOwner::UpdateCurrentImages(nsTArray<GeckoPlanarYCbCrImage> aImages)
+GeckoMediaDecoderOwner::UpdateCurrentImages(
+  nsTArray<GeckoPlanarYCbCrImage> aImages)
 {
   if (mCallback.mContext && mCallback.mUpdateCurrentImages) {
-    (*mCallback.mUpdateCurrentImages)(mCallback.mContext, aImages.Length(), aImages.Elements());
+    (*mCallback.mUpdateCurrentImages)(
+      mCallback.mContext, aImages.Length(), aImages.Elements());
   }
 }
 
@@ -268,7 +270,7 @@ GeckoMediaDecoderOwner::NotifyBuffered() const
       i++;
     }
     (*mCallback.mNotifyBuffered)(mCallback.mContext, size, ranges);
-    delete [] ranges;
+    delete[] ranges;
   }
 }
 

--- a/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
+++ b/gecko-media/gecko/glue/GeckoMediaDecoderOwner.cpp
@@ -5,20 +5,21 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "GeckoMediaDecoderOwner.h"
-#include "mozilla/AbstractThread.h"
-#include "VideoFrameContainer.h"
 #include "ImageContainer.h"
+#include "VideoFrameContainer.h"
+#include "mozilla/AbstractThread.h"
 
 namespace mozilla {
 
-GeckoMediaDecoderOwner::GeckoMediaDecoderOwner(PlayerCallbackObject aCallback)
+GeckoMediaDecoderOwner::GeckoMediaDecoderOwner(PlayerCallbackObject aCallback,
+                                               FrameAllocatorObject aAllocator)
   : mCallback(aCallback)
+  , mAllocator(aAllocator)
 {
 }
 
 GeckoMediaDecoderOwner::GeckoMediaDecoderOwner()
 {
-
 }
 
 void
@@ -213,9 +214,9 @@ VideoFrameContainer*
 GeckoMediaDecoderOwner::GetVideoFrameContainer()
 {
   RefPtr<layers::ImageContainer> container =
-    new layers::ImageContainer(this);
-  mVideoFrameContainer =
-    new VideoFrameContainer(this, container.forget());
+    new layers::ImageContainer(this, mAllocator);
+  mAllocator = { 0 };
+  mVideoFrameContainer = new VideoFrameContainer(this, container.forget());
   return mVideoFrameContainer;
 }
 
@@ -285,7 +286,7 @@ GeckoMediaDecoderOwner::NotifySeekable() const
       i++;
     }
     (*mCallback.mNotifySeekable)(mCallback.mContext, size, ranges);
-    delete [] ranges;
+    delete[] ranges;
   }
 }
 
@@ -293,14 +294,6 @@ void
 GeckoMediaDecoderOwner::Shutdown()
 {
   if (mVideoFrameContainer) {
-    // The ImageContainer keeps a list of the images that it sends out to Rust,
-    // so that if we shutdown, we can deallocate and neuter the images
-    // proactively. If we don't do this, we can end up with crashes if Rust
-    // code on another thread tries to use images after we've shutdown.
-    auto imageContainer = mVideoFrameContainer->GetImageContainer();
-    if (imageContainer) {
-      imageContainer->DeallocateExportedImages();
-    }
     mVideoFrameContainer->ForgetElement();
     mVideoFrameContainer = nullptr;
   }
@@ -308,7 +301,7 @@ GeckoMediaDecoderOwner::Shutdown()
   if (mCallback.mContext && mCallback.mFree) {
     (*mCallback.mFree)(mCallback.mContext);
   }
-  mCallback = {0};
+  mCallback = { 0 };
 }
 
 } // namespace mozilla

--- a/gecko-media/gecko/glue/ImageContainer.cpp
+++ b/gecko-media/gecko/glue/ImageContainer.cpp
@@ -38,11 +38,10 @@
 // #include "mozilla/layers/D3D11YCbCrImage.h"
 // #endif
 
-#include "mozilla/AbstractThread.h"
 #include "GeckoMediaDecoderOwner.h"
-#include "RustServices.h"
-#include "nsClassHashtable.h"
+#include "mozilla/AbstractThread.h"
 #include "mozilla/Assertions.h"
+#include "RustServices.h"
 
 namespace mozilla {
 
@@ -201,70 +200,158 @@ BufferRecycleBin::ClearRecycledBuffers()
 //   }
 // }
 
-ImageContainer::ImageContainer(GeckoMediaDecoderOwner* aOwner)
-: mRecursiveMutex("ImageContainer.mRecursiveMutex"),
-  mGenerationCounter(++sGenerationCounter),
-  mPaintCount(0),
-  mDroppedImageCount(0),
-  mImageFactory(new ImageFactory()),
-  mRecycleBin(new BufferRecycleBin()),
-  // mIsAsync(flag == ASYNCHRONOUS),
-  mCurrentProducerID(-1),
-  mOwner(aOwner)
+class RustBufferAllocator {
+  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(RustBufferAllocator)
+public:
+  explicit RustBufferAllocator(FrameAllocatorObject aAllocator)
+    : mAllocator(aAllocator)
+  {
+  }
+  size_t Allocate(GeckoPlanarYCbCrImageData* aImage) {
+    if (!mAllocator.mContext || !mAllocator.mAllocateFrame) {
+      return 0;
+    }
+    (*mAllocator.mAllocateFrame)(mAllocator.mContext, aImage);
+  }
+  void DropFrame(size_t aHandle) {
+    if (aHandle && mAllocator.mContext && mAllocator.mDropFrame) {
+      mAllocator.mDropFrame(mAllocator.mContext, aHandle);
+    }
+  }
+private:
+  ~RustBufferAllocator() {
+    if (mAllocator.mContext && mAllocator.mFree) {
+      (*mAllocator.mFree)(mAllocator.mContext);
+      mAllocator = { 0 };
+    }
+  }
+  FrameAllocatorObject mAllocator;
+};
+
+class RustPlanarYCbCrImage : public PlanarYCbCrImage {
+public:
+  explicit RustPlanarYCbCrImage(RustBufferAllocator* aContainer)
+    : mAllocator(aContainer)
+  {
+  }
+
+  ~RustPlanarYCbCrImage() override {
+    if (mAllocator && mHandle) {
+      mAllocator->DropFrame(mHandle);
+    }
+  }
+
+  uint8_t* AllocateAndGetNewBuffer(uint32_t aSize) override {
+    return nullptr;
+  }
+
+  size_t SizeOfExcludingThis(MallocSizeOf aMallocSizeOf) const override {
+    return 0;
+  }
+
+  RustPlanarYCbCrImage* AsRustPlanarYCbCrImage() override { return this; }
+
+  bool IsValid() { return mHandle != 0; }
+
+  bool CopyData(const Data& aData) override
+  {
+    // We can only handle non-interleaved image formats.
+    // Fortunately, our decoders only output planar i420
+    // images.
+    MOZ_ASSERT(aData.mYSkip == 0);
+    MOZ_ASSERT(aData.mCbSkip == 0);
+    MOZ_ASSERT(aData.mCrSkip == 0);
+    MOZ_ASSERT(aData.mPicSize.width > 0);
+    MOZ_ASSERT(aData.mPicSize.height > 0);
+
+    GeckoPlanarYCbCrImageData img;
+
+    img.mYPlane.mStride = aData.mYStride;
+    img.mYPlane.mWidth = aData.mYSize.width;
+    img.mYPlane.mHeight = aData.mYSize.height;
+    img.mYPlane.mPixelData = aData.mYChannel;
+
+    img.mCbPlane.mStride = aData.mCbCrStride;
+    img.mCbPlane.mWidth = aData.mCbCrSize.width;
+    img.mCbPlane.mHeight = aData.mCbCrSize.height;
+    img.mCbPlane.mPixelData = aData.mCbChannel;
+
+    img.mCrPlane.mStride = aData.mCbCrStride;
+    img.mCrPlane.mWidth = aData.mCbCrSize.width;
+    img.mCrPlane.mHeight = aData.mCbCrSize.height;
+    img.mCrPlane.mPixelData = aData.mCrChannel;
+
+    img.mPicX = aData.mPicX;
+    img.mPicY = aData.mPicY;
+    img.mPicWidth = aData.mPicSize.width;
+    img.mPicHeight = aData.mPicSize.height;
+
+    mHandle = mAllocator->Allocate(&img);
+
+    mOrigin = gfx::IntPoint(aData.mPicX, aData.mPicY);
+    mSize = gfx::IntSize(aData.mPicSize.width, aData.mPicSize.height);
+
+    return mHandle != 0;
+  }
+  size_t Handle() const { return mHandle; }
+private:
+  size_t mHandle = 0;
+  RefPtr<RustBufferAllocator> mAllocator;
+};
+
+class RustImageFactory : public ImageFactory
 {
-  // if (flag == ASYNCHRONOUS) {
-  //   mNotifyCompositeListener = new ImageContainerListener(this);
-  //   EnsureImageClient();
-  // }
+protected:
+  friend class ImageContainer;
+
+  explicit RustImageFactory(FrameAllocatorObject aAllocator)
+    : mAllocator(new RustBufferAllocator(aAllocator))
+  {}
+
+  RefPtr<PlanarYCbCrImage> CreatePlanarYCbCrImage(
+    const gfx::IntSize& aScaleHint,
+    BufferRecycleBin *aRecycleBin)
+  {
+    return new RustPlanarYCbCrImage(mAllocator);
+  }
+private:
+  RefPtr<RustBufferAllocator> mAllocator;
+};
+
+ImageContainer::ImageContainer(GeckoMediaDecoderOwner* aOwner,
+                               ImageFactory* aImageFactory)
+  : mRecursiveMutex("ImageContainer.mRecursiveMutex")
+  , mGenerationCounter(++sGenerationCounter)
+  , mPaintCount(0)
+  , mDroppedImageCount(0)
+  , mImageFactory(aImageFactory)
+  , mRecycleBin(new BufferRecycleBin())
+  , mCurrentProducerID(-1)
+  , mOwner(aOwner)
+{
 }
 
-// ImageContainer::ImageContainer(const CompositableHandle& aHandle)
-//   : mRecursiveMutex("ImageContainer.mRecursiveMutex"),
-//   mGenerationCounter(++sGenerationCounter),
-//   mPaintCount(0),
-//   mDroppedImageCount(0),
-//   mImageFactory(nullptr),
-//   mRecycleBin(nullptr),
-//   mIsAsync(true),
-//   // mAsyncContainerHandle(aHandle),
-//   mCurrentProducerID(-1)
-// {
-//   // MOZ_ASSERT(mAsyncContainerHandle);
-// }
+ImageContainer::ImageContainer(GeckoMediaDecoderOwner* aOwner)
+  : ImageContainer(aOwner, new ImageFactory())
+{
+}
+
+ImageContainer::ImageContainer(GeckoMediaDecoderOwner* aOwner,
+                               FrameAllocatorObject aAllocator)
+  : ImageContainer(aOwner, new RustImageFactory(aAllocator))
+{
+}
 
 ImageContainer::~ImageContainer()
 {
-  // if (mNotifyCompositeListener) {
-  //   mNotifyCompositeListener->ClearImageContainer();
-  // }
-  // if (mAsyncContainerHandle) {
-  //   if (RefPtr<ImageBridgeChild> imageBridge = ImageBridgeChild::GetSingleton()) {
-  //     imageBridge->ForgetImageContainer(mAsyncContainerHandle);
-  //   }
-  // }
 }
 
 RefPtr<PlanarYCbCrImage>
 ImageContainer::CreatePlanarYCbCrImage()
 {
   RecursiveMutexAutoLock lock(mRecursiveMutex);
-  // EnsureImageClient();
-  // if (mImageClient && mImageClient->AsImageClientSingle()) {
-  //   return new SharedPlanarYCbCrImage(mImageClient);
-  // }
   return mImageFactory->CreatePlanarYCbCrImage(mScaleHint, mRecycleBin);
 }
-
-// RefPtr<SharedRGBImage>
-// ImageContainer::CreateSharedRGBImage()
-// {
-//   RecursiveMutexAutoLock lock(mRecursiveMutex);
-//   EnsureImageClient();
-//   if (!mImageClient || !mImageClient->AsImageClientSingle()) {
-//     return nullptr;
-//   }
-//   return new SharedRGBImage(mImageClient);
-// }
 
 void
 ImageContainer::SetCurrentImageInternal(const nsTArray<NonOwningImage>& aImages)
@@ -360,121 +447,6 @@ private:
   RefPtr<GeckoMediaDecoderOwner> mOwner;
 };
 
-struct ExportedImage {
-  ExportedImage(Image* aImage, ImageContainer* aContainer)
-    : mImage(aImage)
-    , mContainer(aContainer)
-  {
-    MOZ_ASSERT(mImage);
-    MOZ_ASSERT(mContainer);
-  }
-  ExportedImage(const ExportedImage& aOther)
-    : mImage(aOther.mImage)
-    , mContainer(aOther.mContainer)
-  {
-  }
-  ExportedImage(ExportedImage&& aOther)
-    : mImage(Move(aOther.mImage))
-    , mContainer(Move(aOther.mContainer))
-  {
-  }
-  RefPtr<Image> mImage;
-  RefPtr<ImageContainer> mContainer;
-  uint32_t mRefCount = 0;
-};
-
-StaticMutex sImageMutex;
-static nsClassHashtable<nsUint32HashKey, ExportedImage> sImages;
-
-void PlanarYCbCrImage_AddRefPixelData(uint32_t aFrameID)
-{
-  StaticMutexAutoLock lock(sImageMutex);
-  ExportedImage* img = sImages.Get(aFrameID);
-  if (img) {
-    img->mRefCount += 1;
-  }
-}
-
-void PlanarYCbCrImage_FreeData(uint32_t aFrameID) {
-  StaticMutexAutoLock lock(sImageMutex);
-  ExportedImage* img = sImages.Get(aFrameID);
-  if (img && img->mRefCount == 0) {
-    img->mContainer->RecordImageDropped(aFrameID);
-    sImages.Remove(aFrameID);
-  }
-}
-
-const uint8_t*
-PlanarYCbCrImage_GetPixelData(uint32_t aFrameID, PlaneType aPlaneType)
-{
-  RefPtr<Image> img;
-  {
-    StaticMutexAutoLock lock(sImageMutex);
-    ExportedImage* i = sImages.Get(aFrameID);
-    if (!i) {
-      return nullptr;
-    }
-    img = i->mImage;
-  }
-  PlanarYCbCrImage* planarImage = img->AsPlanarYCbCrImage();
-  MOZ_ASSERT(planarImage);
-  if (!planarImage) {
-    return nullptr;
-  }
-  const PlanarYCbCrData* data = planarImage->GetData();
-  switch (aPlaneType) {
-    case PlaneType::Y: return data->mYChannel;
-    case PlaneType::Cb: return data->mCbChannel;
-    case PlaneType::Cr: return data->mCrChannel;
-  }
-  return nullptr;
-}
-
-ByteSlice
-PlanarYCbCrImage_GetSliceData(uint32_t aFrameID)
-{
-  RefPtr<Image> img;
-  {
-    StaticMutexAutoLock lock(sImageMutex);
-    ExportedImage* i = sImages.Get(aFrameID);
-    if (!i) {
-      return ByteSlice { nullptr, 0 };
-    }
-    img = i->mImage;
-  }
-  PlanarYCbCrImage* planarImage = img->AsPlanarYCbCrImage();
-  MOZ_ASSERT(planarImage);
-  if (!planarImage) {
-    return ByteSlice { nullptr, 0 };
-  }
-  const PlanarYCbCrData* data = planarImage->GetData();
-  const uint8_t* ptr = data->mYChannel;
-  size_t length = planarImage->GetDataSize();
-  return ByteSlice { ptr, length };
-}
-
-void
-ImageContainer::DeallocateExportedImages()
-{
-  StaticMutexAutoLock lock(sImageMutex);
-  for (size_t frameId : mExportedImages) {
-    sImages.Remove(frameId);
-  }
-  mExportedImages.Clear();
-}
-
-void
-ImageContainer::RecordImageExported(size_t aFrameID)
-{
-  mExportedImages.AppendElement(aFrameID);
-}
-
-void
-ImageContainer::RecordImageDropped(size_t aFrameID)
-{
-  mExportedImages.RemoveElement(aFrameID);
-}
-
 void
 ImageContainer::NotifyOwnerOfNewImages()
 {
@@ -485,29 +457,15 @@ ImageContainer::NotifyOwnerOfNewImages()
   nsTArray<GeckoPlanarYCbCrImage> images;
   for (const OwningImage& owningImage : mCurrentImages) {
 
-    PlanarYCbCrImage* planarImage = owningImage.mImage->AsPlanarYCbCrImage();
+    RustPlanarYCbCrImage* planarImage = owningImage.mImage->AsRustPlanarYCbCrImage();
     MOZ_ASSERT(planarImage);
     if (!planarImage) {
       continue;
     }
-    const PlanarYCbCrData* data = planarImage->GetData();
 
     GeckoPlanarYCbCrImage* img = images.AppendElement();
-
-    img->mYStride = data->mYStride;
-    img->mYWidth = data->mYSize.width;
-    img->mYHeight = data->mYSize.height;
-    img->mYSkip = data->mYSkip;
-    img->mCbCrStride = data->mCbCrStride;
-    img->mCbCrWidth = data->mCbCrSize.width;
-    img->mCbCrHeight = data->mCbCrSize.height;
-    img->mCbSkip = data->mCbSkip;
-    img->mCrSkip = data->mCrSkip;
-    img->mPicX = data->mPicX;
-    img->mPicY = data->mPicY;
-    img->mPicWidth = data->mPicSize.width;
-    img->mPicHeight = data->mPicSize.height;
     img->mFrameID = owningImage.mFrameID;
+    img->mImageHandle = planarImage->Handle();
 
     // Calculate a TimeStamp in the external frame of reference.
     // Note the OwningImage can have a null TimeStamp if we're
@@ -518,21 +476,6 @@ ImageContainer::NotifyOwnerOfNewImages()
     TimeStamp now = TimeStamp::Now();
     TimeStamp frameTime = !owningImage.mTimeStamp.IsNull() ? owningImage.mTimeStamp : now;
     img->mTimeStamp = rustTime + (frameTime - now).ToMicroseconds() * 1000.0;
-
-    {
-      StaticMutexAutoLock lock(sImageMutex);
-      if (!sImages.Contains(img->mFrameID)) {
-        sImages.Put(img->mFrameID, new ExportedImage(owningImage.mImage, this));
-        RecordImageExported(img->mFrameID);
-      } else {
-        sImages.Get(img->mFrameID)->mRefCount += 1;
-      }
-    }
-
-    img->mAddRefPixelData = &PlanarYCbCrImage_AddRefPixelData;
-    img->mFreePixelData = &PlanarYCbCrImage_FreeData;
-    img->mGetPixelData = &PlanarYCbCrImage_GetPixelData;
-    img->mGetSliceData = &PlanarYCbCrImage_GetSliceData;
   }
 
   RefPtr<Runnable> task = new UpdateCurrentImagesRunnable(mOwner, Move(images));

--- a/gecko-media/gecko/glue/MediaData.cpp
+++ b/gecko-media/gecko/glue/MediaData.cpp
@@ -252,6 +252,10 @@ ConstructPlanarYCbCrData(const VideoInfo& aInfo,
   data.mPicX = aPicture.x;
   data.mPicY = aPicture.y;
   data.mPicSize = aPicture.Size();
+  MOZ_ASSERT(aPicture.width > 0);
+  MOZ_ASSERT(aPicture.height > 0);
+  MOZ_ASSERT(data.mPicSize.width > 0);
+  MOZ_ASSERT(data.mPicSize.height > 0);
   data.mStereoMode = aInfo.mStereoMode;
   data.mYUVColorSpace = aBuffer.mYUVColorSpace;
   // data.mBitDepth = aBuffer.mBitDepth;
@@ -308,6 +312,9 @@ VideoData::CreateAndCopyData(const VideoInfo& aInfo,
   if (!ValidateBufferAndPicture(aBuffer, aPicture)) {
     return nullptr;
   }
+
+  MOZ_ASSERT(aPicture.width > 0);
+  MOZ_ASSERT(aPicture.height > 0);
 
   RefPtr<VideoData> v(new VideoData(aOffset,
                                     aTime,

--- a/gecko-media/gecko/glue/include/GeckoMediaDecoderOwner.h
+++ b/gecko-media/gecko/glue/include/GeckoMediaDecoderOwner.h
@@ -30,10 +30,10 @@ class HTMLMediaElement;
 class GeckoMediaDecoderOwner : public MediaDecoderOwner
 {
 public:
-
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(GeckoMediaDecoderOwner)
 
-  GeckoMediaDecoderOwner(PlayerCallbackObject aCallback);
+  GeckoMediaDecoderOwner(PlayerCallbackObject aCallback,
+                         FrameAllocatorObject aAllocator);
   GeckoMediaDecoderOwner();
 
   // Called by the media decoder to indicate that the download is progressing.
@@ -208,6 +208,7 @@ private:
 
   bool mHasError = false;
   PlayerCallbackObject mCallback = { 0 };
+  FrameAllocatorObject mAllocator = { 0 };
   RefPtr<GeckoMediaDecoder> mDecoder;
   RefPtr<VideoFrameContainer> mVideoFrameContainer;
 };

--- a/gecko-media/gecko/glue/include/GeckoMediaDecoderOwner.h
+++ b/gecko-media/gecko/glue/include/GeckoMediaDecoderOwner.h
@@ -191,8 +191,9 @@ public:
 
   // Called after the MediaStream we're playing rendered a frame to aContainer
   // with a different principalHandle than the previous frame.
-  void PrincipalHandleChangedForVideoFrameContainer(VideoFrameContainer* aContainer,
-                                                    const PrincipalHandle& aNewPrincipalHandle) override;
+  void PrincipalHandleChangedForVideoFrameContainer(
+    VideoFrameContainer* aContainer,
+    const PrincipalHandle& aNewPrincipalHandle) override;
 
   void SetDecoder(GeckoMediaDecoder* aDecoder);
 

--- a/gecko-media/gecko/glue/include/ImageContainer.h
+++ b/gecko-media/gecko/glue/include/ImageContainer.h
@@ -34,6 +34,7 @@
 #include "nsDataHashtable.h"
 #include "mozilla/EnumeratedArray.h"
 #include "mozilla/UniquePtr.h"
+#include "Player.h"
 
 #ifndef XPCOM_GLUE_AVOID_NSPR
 /**
@@ -163,6 +164,7 @@ class PlanarYCbCrImage;
 class TextureClient;
 class KnowsCompositor;
 class NVImage;
+class RustPlanarYCbCrImage;
 #ifdef XP_WIN
 class D3D11YCbCrRecycleAllocator;
 #endif
@@ -243,6 +245,7 @@ public:
 //   virtual MacIOSurfaceImage* AsMacIOSurfaceImage() { return nullptr; }
 // #endif
   virtual PlanarYCbCrImage* AsPlanarYCbCrImage() { return nullptr; }
+  virtual RustPlanarYCbCrImage* AsRustPlanarYCbCrImage() { return nullptr; }
 
   // virtual NVImage* AsNVImage() { return nullptr; }
 
@@ -355,6 +358,7 @@ protected:
 //   ImageContainer* mImageContainer;
 // };
 
+
 /**
  * A class that manages Images for an ImageLayer. The only reason
  * we need a separate class here is that ImageLayers aren't threadsafe
@@ -383,6 +387,9 @@ class ImageContainer final : public SupportsWeakPtr<ImageContainer>
 
   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(ImageContainer)
 
+  ImageContainer(GeckoMediaDecoderOwner* aOwner,
+                 ImageFactory* aImageFactory);
+
 public:
   MOZ_DECLARE_WEAKREFERENCE_TYPENAME(ImageContainer)
 
@@ -391,6 +398,9 @@ public:
   static const uint64_t sInvalidAsyncContainerId = 0;
 
   explicit ImageContainer(GeckoMediaDecoderOwner* aOwner);
+
+  ImageContainer(GeckoMediaDecoderOwner* aOwner,
+                 FrameAllocatorObject aAllocator);
 
   /**
    * Create ImageContainer just to hold another ASYNCHRONOUS ImageContainer's
@@ -621,9 +631,6 @@ public:
   static ProducerID AllocateProducerID();
 
   // void DropImageClient();
-
-  void DeallocateExportedImages();
-  void RecordImageDropped(size_t aFrameID);
 
 private:
   typedef mozilla::RecursiveMutex RecursiveMutex;

--- a/gecko-media/gecko/glue/include/Player.h
+++ b/gecko-media/gecko/glue/include/Player.h
@@ -32,39 +32,32 @@ enum PlaneType
   Cr
 };
 
-struct ByteSlice {
-  const uint8_t* mData;
-  size_t mLength;
+struct GeckoImagePlane
+{
+  int32_t mStride;
+  int32_t mWidth;
+  int32_t mHeight;
+  const uint8_t* mPixelData;
 };
 
-struct GeckoPlanarYCbCrImage
+struct GeckoPlanarYCbCrImageData
 {
-  // Luminance buffer
-  int32_t mYStride;
-  int32_t mYWidth;
-  int32_t mYHeight;
-  int32_t mYSkip;
-
-  // Chroma buffers
-  int32_t mCbCrStride;
-  int32_t mCbCrWidth;
-  int32_t mCbCrHeight;
-  int32_t mCbSkip;
-  int32_t mCrSkip;
+  GeckoImagePlane mYPlane;
+  GeckoImagePlane mCbPlane;
+  GeckoImagePlane mCrPlane;
 
   // Picture region
   uint32_t mPicX;
   uint32_t mPicY;
   int32_t mPicWidth;
   int32_t mPicHeight;
+};
 
+struct GeckoPlanarYCbCrImage
+{
+  size_t mImageHandle;
   uint64_t mTimeStamp;
   uint32_t mFrameID;
-
-  void (*mAddRefPixelData)(uint32_t aFrameID);
-  void (*mFreePixelData)(uint32_t aFrameID);
-  const uint8_t* (*mGetPixelData)(uint32_t aFrameID, PlaneType aPlaneType);
-  ByteSlice (*mGetSliceData)(uint32_t aFrameID);
 };
 
 struct PlayerCallbackObject
@@ -85,23 +78,41 @@ struct PlayerCallbackObject
   void (*mFree)(void*);
 };
 
-struct GeckoMediaByteRange {
+struct FrameAllocatorObject
+{
+  void* mContext;
+  size_t (*mAllocateFrame)(void*, const GeckoPlanarYCbCrImageData* aImage);
+  void (*mDropFrame)(void*, size_t);
+  void (*mFree)(void*);
+};
+
+struct GeckoMediaByteRange
+{
   uint64_t mStart;
   uint64_t mEnd;
 };
 
-struct CachedRangesObserverObject {
+struct CachedRangesObserverObject
+{
   void (*mUpdate)(uint32_t, const GeckoMediaByteRange*, size_t);
   uint32_t mResourceID;
 };
 
-struct NetworkResourceObject {
+struct NetworkResourceObject
+{
   void (*mSetRangesObserver)(void*, CachedRangesObserverObject);
-  bool (*mReadAt)(void* aData, uint64_t aOffset, uint8_t* aBytes, uint32_t aLength, uint32_t* aOutBytesRead);
+  bool (*mReadAt)(void* aData,
+                  uint64_t aOffset,
+                  uint8_t* aBytes,
+                  uint32_t aLength,
+                  uint32_t* aOutBytesRead);
   void (*mPin)(void* aData);
   void (*mUnPin)(void* aData);
   int64_t (*mLength)(void* aData);
-  bool (*mReadFromCache)(void* aData, uint64_t aOffset, uint8_t* aBytes, uint32_t aLength);
+  bool (*mReadFromCache)(void* aData,
+                         uint64_t aOffset,
+                         uint8_t* aBytes,
+                         uint32_t aLength);
   void (*mFree)(void*);
   void* mData;
 };
@@ -111,13 +122,15 @@ void
 GeckoMedia_Player_CreateBlobPlayer(size_t aId,
                                    RustVecU8Object aMediaData,
                                    const char* aMimeType,
-                                   PlayerCallbackObject aCallback);
+                                   PlayerCallbackObject aCallback,
+                                   FrameAllocatorObject aAllocator);
 
 void
 GeckoMedia_Player_CreateNetworkPlayer(size_t aId,
                                       NetworkResourceObject aMediaData,
                                       const char* aMimeType,
-                                      PlayerCallbackObject aCallback);
+                                      PlayerCallbackObject aCallback,
+                                      FrameAllocatorObject aAllocator);
 
 void
 GeckoMedia_Player_Play(size_t aId);

--- a/gecko-media/gecko/glue/include/Player.h
+++ b/gecko-media/gecko/glue/include/Player.h
@@ -32,6 +32,11 @@ enum PlaneType
   Cr
 };
 
+struct ByteSlice {
+  const uint8_t* mData;
+  size_t mLength;
+};
+
 struct GeckoPlanarYCbCrImage
 {
   // Luminance buffer
@@ -59,6 +64,7 @@ struct GeckoPlanarYCbCrImage
   void (*mAddRefPixelData)(uint32_t aFrameID);
   void (*mFreePixelData)(uint32_t aFrameID);
   const uint8_t* (*mGetPixelData)(uint32_t aFrameID, PlaneType aPlaneType);
+  ByteSlice (*mGetSliceData)(uint32_t aFrameID);
 };
 
 struct PlayerCallbackObject

--- a/gecko-media/src/mse/sourcebuffer.rs
+++ b/gecko-media/src/mse/sourcebuffer.rs
@@ -9,11 +9,13 @@ use std::rc::Rc;
 def_gecko_media_struct!(SourceBuffer);
 
 impl SourceBuffer {
-    pub fn new(gecko_media: GeckoMedia,
-               id: usize,
-               callbacks: Rc<SourceBufferImpl>,
-               parent_id: usize,
-               mime: &str) -> Result<Self, ()> {
+    pub fn new(
+        gecko_media: GeckoMedia,
+        id: usize,
+        callbacks: Rc<SourceBufferImpl>,
+        parent_id: usize,
+        mime: &str,
+    ) -> Result<Self, ()> {
         let callbacks = to_ffi_callbacks(callbacks);
         let mime = match CString::new(mime.as_bytes()) {
             Ok(mime) => mime,

--- a/gecko-media/src/player.rs
+++ b/gecko-media/src/player.rs
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+use bindings::NetworkResourceObject;
 use bindings::{CachedRangesObserverObject, FrameAllocatorObject, GeckoImagePlane};
 use bindings::{GeckoMediaByteRange, GeckoPlanarYCbCrImage, GeckoPlanarYCbCrImageData};
 use bindings::{GeckoMediaMetadata, GeckoMediaTimeInterval};
 use bindings::{GeckoMedia_Player_CreateBlobPlayer, GeckoMedia_Player_CreateNetworkPlayer};
 use bindings::{GeckoMedia_Player_Pause, GeckoMedia_Player_Play};
 use bindings::{GeckoMedia_Player_Seek, GeckoMedia_Player_SetVolume};
-use bindings::NetworkResourceObject;
 use bindings::{PlayerCallbackObject, RustVecU8Object};
 use std::ffi::CStr;
 use std::ffi::CString;


### PR DESCRIPTION
To resolve the problems in issue #112 and to remove the potential use-after-free which can happen if GeckoMedia shuts down and deallocates video frames before the compositor is finished painting video frames, switch to having the video frames stored in Rust allocated Vec<u8>s which are ref counted. This means we won't deallocate the memory until the last Rust or C++ user of the data is destroyed.