### PR TITLE
Ensure we return the frame id when allocating frames.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: 9000
 language: rust
 rust:
-  - nightly
+  - stable
 os:
   - linux
   - osx

--- a/gecko-media/gecko/glue/ImageContainer.cpp
+++ b/gecko-media/gecko/glue/ImageContainer.cpp
@@ -211,7 +211,7 @@ public:
     if (!mAllocator.mContext || !mAllocator.mAllocateFrame) {
       return 0;
     }
-    (*mAllocator.mAllocateFrame)(mAllocator.mContext, aImage);
+    return (*mAllocator.mAllocateFrame)(mAllocator.mContext, aImage);
   }
   void DropFrame(size_t aHandle) {
     if (aHandle && mAllocator.mContext && mAllocator.mDropFrame) {


### PR DESCRIPTION
This fixes issue 138, rendering on MacOS.